### PR TITLE
Update support information.

### DIFF
--- a/README
+++ b/README
@@ -125,7 +125,14 @@ or
 
 The driver is maintained by a mailing list:
 
-  perl@lists.mysql.com
+This module is maintained and supported on a mailing list, dbi-users.
+To subscribe to this list, send and email to
+
+  dbi-users-subscribe@perl.org
+
+Mailing list archives are at
+
+  http://groups.google.com/group/perl.dbi.users?hl=en&lr=
 
 You can also get help from the maintainer, Patrick Galbraith patg@patg.net
 

--- a/lib/DBD/mysql/INSTALL.pod
+++ b/lib/DBD/mysql/INSTALL.pod
@@ -28,12 +28,7 @@ sections. L<BINARY INSTALLATION>. L<SOURCE INSTALLATION>.
 
 Finally, if you encounter any problems, do not forget to
 read the section on known problems. L<KNOWN PROBLEMS>. If
-that doesn't help, you should look into the archive of the
-mailing list B<perl@lists.mysql.com>. See
-http://www.mysql.com for archive locations. And if that
-still doesn't help, please post a question on this mailing
-list.
-
+that doesn't help, you should check the section on L<SUPPORT>.
 
 =head1 PREREQUISITES
 
@@ -793,8 +788,12 @@ before runing 'perl Makefile.PL'
 
 Finally, if everything else fails, you are not alone. First of
 all, for an immediate answer, you should look into the archives
-of the mailing list B<perl@lists.mysql.com>. See
-http://www.mysql.com for archive locations.
+of the dbi-users mailing list, which is available at
+L<http://groups.google.com/group/perl.dbi.users?hl=en&lr=>
+
+To subscribe to this list, send and email to
+
+dbi-users-subscribe@perl.org
 
 If you don't find an appropriate posting and reply in the
 mailing list, please post a question. Typically a reply will


### PR DESCRIPTION
mysql.pm already pointed to dbi-users, README and INSTALL.pod pointed
to a not very active list on MySQL.com. I took the liberty of making it
consistent by means of pointing all to dbi-users.
