### PR TITLE
Fixed test 70takeimp warning.

### DIFF
--- a/t/70takeimp.t
+++ b/t/70takeimp.t
@@ -102,7 +102,7 @@ is $drh2->{ActiveKids}, 1,
 read_write_test($dbh2);
 
 # must cut the connection data again
-ok ($imp_data = $dbh2->take_imp_data), "didn't get imp_data";
+ok ($imp_data = $dbh2->take_imp_data, "didn't get imp_data");
 
 
 sub read_write_test {


### PR DESCRIPTION
If you ran it you'd see:

```
Useless use of a constant ("didn't get imp_data") in void context at t/70takeimp.t line 105
```

Fixed this warning by correctly using ok(..., '...');
