### PR TITLE
Undefined $DBI::errstr on execute fail on Windows

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3285,6 +3285,8 @@ my_ulonglong mysql_st_internal_execute(
       }
 #if MYSQL_ASYNC
   }
+#endif
+
   Safefree(salloc);
 
   if(rows == -2) {
@@ -3294,7 +3296,6 @@ my_ulonglong mysql_st_internal_execute(
       PerlIO_printf(DBIc_LOGPIO(imp_xxh), "IGNORING ERROR errno %d\n", errno);
     rows = -2;
   }
-#endif
   return(rows);
 }
 


### PR DESCRIPTION
This is actually a very important fix, without this errstr is not set on Windows!

It has been reported here:
https://rt.cpan.org/Ticket/Display.html?id=71047 - "Undefined $DBI::errstr on execute fail on Windows-7-x64"
https://rt.cpan.org/Ticket/Display.html?id=83353
http://bugs.activestate.com/show_bug.cgi?id=91026
http://lists.mysql.com/perl/4415
http://stackoverflow.com/questions/7432944/undefined-dbierrstr-using-dbi-perl-and-mysql-on-windows-7-x64
http://blogs.perl.org/users/mithaldu/2011/10/dbdmysql-4019-and-4020-are-broken-on-win32-heres-how-to-downgrade.html
