### PR TITLE
Change environment variables for extended tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_script:
   - mysql -e 'create database myapp_test;'
 install:
    - cpanm Test::Deep DBI
-env: SLOW_TESTS=1
+env: EXTENDED_TESTING=1
 script: "perl Makefile.PL --testuser=travis --testdb myapp_test && make && make test"

--- a/t/60leaks.t
+++ b/t/60leaks.t
@@ -19,8 +19,8 @@ my $COUNT_PREPARE = 10000;  # Number of prepare/execute/finish iterations
 
 my $have_storable;
 
-if (!$ENV{SLOW_TESTS}) {
-    plan skip_all => "Skip \$ENV{SLOW_TESTS} is not set\n";
+if (!$ENV{EXTENDED_TESTING}) {
+    plan skip_all => "Skip \$ENV{EXTENDED_TESTING} is not set\n";
 }
 
 eval { require Proc::ProcessTable; };


### PR DESCRIPTION
'Lancaster' specifies this should be 'EXTENDED_TESTING'.
See https://github.com/Perl-Toolchain-Gang/toolchain-site/blob/master/lancaster-consensus.md

Thanks to Leon Timmermans for the suggestion!
