### PR TITLE
Fix method redefinition warnings in threads on Perl >= 5.16

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 2013-??-?? Patrick Galbraith, Michiel Beijen, DBI/DBD community (4.025)
+* Fix method redefinition warnings in threads on Perl >= 5.16 - Dagfinn Ilmari Mannsåker
 * use strict and warnings everywhere.
 * Minimum perl version is now 5.8.1, just as for DBI.
 * Improved database version check so tests run correctly on MariaDB 10.

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -22,6 +22,7 @@ our $err = 0;	# holds error code   for DBI::err
 our $errstr = "";	# holds error string for DBI::errstr
 our $drh = undef;	# holds driver handle once initialised
 
+my $methods_are_installed = 0;
 sub driver{
     return $drh if $drh;
     my($class, $attr) = @_;
@@ -36,11 +37,15 @@ sub driver{
 				   'Attribution' => 'DBD::mysql by Patrick Galbraith'
 				 });
 
-    DBD::mysql::db->install_method('mysql_fd');
-    DBD::mysql::db->install_method('mysql_async_result');
-    DBD::mysql::db->install_method('mysql_async_ready');
-    DBD::mysql::st->install_method('mysql_async_result');
-    DBD::mysql::st->install_method('mysql_async_ready');
+    if (!$methods_are_installed) {
+	DBD::mysql::db->install_method('mysql_fd');
+	DBD::mysql::db->install_method('mysql_async_result');
+	DBD::mysql::db->install_method('mysql_async_ready');
+	DBD::mysql::st->install_method('mysql_async_result');
+	DBD::mysql::st->install_method('mysql_async_ready');
+
+	$methods_are_installed++;
+    }
 
     $drh;
 }


### PR DESCRIPTION
$drh gets cleared on CLONE, but the driver methods persist.
Due to a bug, this didn't warn until Perl 5.16

```
$ perl -Mthreads -MDBI -MDBD::mysql -we 'DBI->setup_driver("DBD::mysql");' \
  -e 'DBD::mysql->driver; threads->create(sub { DBD::mysql->driver })->join'
Subroutine DBI::db::mysql_fd redefined at ${archlib}/DBI.pm line 1393.
Subroutine DBI::db::mysql_async_result redefined at ${archlib}/DBI.pm line 1393.
Subroutine DBI::db::mysql_async_ready redefined at ${archlib}/DBI.pm line 1393.
Subroutine DBI::st::mysql_async_result redefined at ${archlib}/DBI.pm line 1393.
Subroutine DBI::st::mysql_async_ready redefined at ${archlib}/DBI.pm line 1393.
```
