### PR TITLE
remove mysql_config's options not compatible with MariaDB

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,23 +19,9 @@ our $opt = { "help" => \&Usage, };
 Getopt::Long::GetOptions(
     $opt,
     "help",
-    "testdb=s",
-    "testhost=s",
-    "testport=s",
-    "testuser=s",
-    "testpassword=s",
-    "testsocket=s",
     "cflags=s",
     "libs=s",
-    "verbose",
-    "ps-protocol",
-    "bind-type-guessing",
-    "nocatchstderr",
-    "ssl!",
-    "nofoundrows!",
-    "embedded=s",
     "mysql_config=s",
-    "force-embedded",
 	"with-mysql=s"
     ) || die Usage();
 
@@ -78,9 +64,7 @@ MSG
     $opt->{'mysql_config'} = "mysql_config";
   }
 
-for my $key (qw/testdb testhost testuser testpassword testsocket testport
-                    cflags embedded libs nocatchstderr ssl nofoundrows
-                    ps-protocol bind-type-guessing force-embedded/)
+for my $key (qw/cflags embedded libs/)
 {
   Configure($opt, $source, $key);
 }
@@ -174,15 +158,6 @@ for my $key (sort { $a cmp $b} keys %$opt)
   printf("  %-" . $keylen . "s (%-" . $slen . "s) = %s\n",
 	 $key, $source->{$key}, $opt->{$key})
 }
-
-print <<"MSG";
-
-To change these settings, see 'perl Makefile.PL --help' and
-'perldoc DBD::mysql::INSTALL'.
-
-MSG
-
-sleep 5;
 
 eval { require File::Spec };
 my $dsn= '';
@@ -430,7 +405,6 @@ it can be found):
   mysql_config --cflags
   mysql_config --libs
   mysql_config --embedded
-  mysql_config --testdb
 
 and so on. See DBD::mysql::INSTALL for details.
 USAGE
@@ -467,6 +441,7 @@ sub Configure {
     }
 
 # First try to get options values from mysql_config
+
     my $command = $opt->{'mysql_config'} . " --$param";
     eval
     {

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2063,6 +2063,7 @@ static int my_login(pTHX_ SV* dbh, imp_dbh_t *imp_dbh)
   if (fresh && !result) {
       /* Prevent leaks, but do not free in case of a reconnect. See #97625 */
       Safefree(imp_dbh->pmysql);
+      imp_dbh->pmysql = NULL;
   }
   return result;
 }
@@ -4953,9 +4954,11 @@ int mysql_db_reconnect(SV* h)
    */
   if (!dbd_db_disconnect(h, imp_dbh) || !my_login(aTHX_ h, imp_dbh))
   {
-    do_error(h, mysql_errno(imp_dbh->pmysql), mysql_error(imp_dbh->pmysql),
+    if(!imp_dbh->pmysql) {
+    	do_error(h, mysql_errno(imp_dbh->pmysql), mysql_error(imp_dbh->pmysql),
              mysql_sqlstate(imp_dbh->pmysql));
-    memcpy (imp_dbh->pmysql, &save_socket, sizeof(save_socket));
+    	memcpy (imp_dbh->pmysql, &save_socket, sizeof(save_socket));
+    }
     ++imp_dbh->stats.auto_reconnects_failed;
     return FALSE;
   }

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2061,6 +2061,8 @@ static int my_login(pTHX_ SV* dbh, imp_dbh_t *imp_dbh)
   result = mysql_dr_connect(dbh, imp_dbh->pmysql, mysql_socket, host, port, user,
 			  password, dbname, imp_dbh) ? TRUE : FALSE;
   if (fresh && !result) {
+      do_error(dbh, mysql_errno(imp_dbh->pmysql),
+              mysql_error(imp_dbh->pmysql) ,mysql_sqlstate(imp_dbh->pmysql));
       /* Prevent leaks, but do not free in case of a reconnect. See #97625 */
       Safefree(imp_dbh->pmysql);
       imp_dbh->pmysql = NULL;


### PR DESCRIPTION
Some options of the program mysql_config are not compatible with MariaDB (they have been removed), use only the options compatible both with MySQL and MariaDB