### PR TITLE
Prepared statement and mysql v5.6+ fixes

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2819,7 +2819,7 @@ dbd_st_prepare(
           isspace(*(str_ptr + 6)))
       {
         if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-          PerlIO_printf(DBILOGFP, "LIMIT set limit flag to 1\n");
+          PerlIO_printf(DBIc_LOGPIO(imp_xxh), "LIMIT set limit flag to 1\n");
         limit_flag= 1;
       }
 #endif
@@ -2834,7 +2834,7 @@ dbd_st_prepare(
            isspace(*(str_ptr + 4)))
       {
         if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-          PerlIO_printf(DBILOGFP, "Disable PS mode for CALL()\n");
+          PerlIO_printf(DBIc_LOGPIO(imp_xxh), "Disable PS mode for CALL()\n");
         imp_sth->use_server_side_prepare= 0;
         break;
       }

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -228,6 +228,7 @@ typedef struct imp_sth_phb_st {
 typedef struct imp_sth_fbh_st {
     unsigned long  length;
     bool           is_null;
+    bool           error;
     char           *data;
     int            charsetnr;
     double         ddata;

--- a/t/50chopblanks.t
+++ b/t/50chopblanks.t
@@ -17,9 +17,9 @@ if ($@) {
     plan skip_all =>
         "ERROR: $DBI::errstr. Can't continue test";
 }
-plan tests => 36;
+plan tests => 36 * 2;
 
-for my $mysql_server_prepare (0) {
+for my $mysql_server_prepare (0, 1) {
 eval {$dbh= DBI->connect($test_dsn . ';mysql_server_prepare=' . $mysql_server_prepare, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 1, AutoCommit => 1 });};
 

--- a/t/lib.pl
+++ b/t/lib.pl
@@ -207,6 +207,7 @@ sub DbiError ($$) {
     my ($rc, $err) = @_;
     $rc ||= 0;
     $err ||= '';
+    $::numTests ||= 0;
     print "Test $::numTests: DBI error $rc, $err\n";
 }
 


### PR DESCRIPTION
This includes the following fixes, as per individual commits:
* Server prepared statement not dealing with truncated response from mysql_stmt_fetch
* Prepared statement version corrections.
* Support testing innodb under mysql 5.6+
* undef warning in DbiError if triggered.

This passes a full test run no FreeBSD 10.1 against mysql 5.6.22 including extended tests.