### PR TITLE
Allow several spaces after LIMIT clause.

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -607,8 +607,8 @@ static char *parse_params(
         it would be good to be able to handle any number of cases and orders
       */
       if ((*statement_ptr == 'l' || *statement_ptr == 'L') &&
-          (!strncmp(statement_ptr+1, "imit ?", 6) ||
-           !strncmp(statement_ptr+1, "IMIT ?", 6)))
+          (!strncmp(statement_ptr+1, "imit ", 5) ||
+           !strncmp(statement_ptr+1, "IMIT ", 5)))
       {
         limit_flag = 1;
       }


### PR DESCRIPTION
Previously the need to interpret bind variable as number was determined
based on presence of 'limit ?', 'Limit ?', 'lIMIT ?', 'LIMIT ?' in the
query. I.e. if there is indeed a LIMIT clause and it is followed by a
single whitespace and a bind variable placeholder. This makes it
impossible to write queries with multiple whitespaces after LIMIT clause
without explicit type binding.
