### PR TITLE
Corrected name of INSTALL.pm in POD

### DIFF
--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -981,7 +981,7 @@ them. :-)
 
 In what follows we first discuss the use of DBD::mysql,
 because this is what you will need the most. For installation, see the
-separate document L<DBD::mysql::INSTALLATION>.
+separate document L<DBD::mysql::INSTALL>.
 See L</"EXAMPLE"> for a simple example above.
 
 From perl you activate the interface with the statement
@@ -1914,7 +1914,7 @@ Here's an example of how to use the asynchronous query interface:
 
 =head1 INSTALLATION
 
-See L<DBD::mysql::INSTALLATION>.
+See L<DBD::mysql::INSTALL>.
 
 =head1 AUTHORS
 


### PR DESCRIPTION
The links to DBD::mysql::INSTALL are broken in the main module POD.