### PR TITLE
indented pasted output from 'explain select's so that it looks better html-ified (on metacpan, etc)

### DIFF
--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1578,34 +1578,34 @@ character column, if this column is indexed, if you query that
 column with the integer value not being quoted, it will not
 use the index:
 
-MariaDB [test]> explain select * from test where value0 = '3' \G
-*************************** 1. row ***************************
-           id: 1
-  select_type: SIMPLE
-        table: test
-         type: ref
-possible_keys: value0
-          key: value0
-      key_len: 13
-          ref: const
-         rows: 1
-        Extra: Using index condition
-1 row in set (0.00 sec)
-
-MariaDB [test]> explain select * from test where value0 = 3
-    -> \G
-*************************** 1. row ***************************
-           id: 1
-  select_type: SIMPLE
-        table: test
-         type: ALL
-possible_keys: value0
-          key: NULL
-      key_len: NULL
-          ref: NULL
-         rows: 6
-        Extra: Using where
-1 row in set (0.00 sec)
+    MariaDB [test]> explain select * from test where value0 = '3' \G
+    *************************** 1. row ***************************
+               id: 1
+      select_type: SIMPLE
+            table: test
+             type: ref
+    possible_keys: value0
+              key: value0
+          key_len: 13
+              ref: const
+             rows: 1
+            Extra: Using index condition
+    1 row in set (0.00 sec)
+    
+    MariaDB [test]> explain select * from test where value0 = 3
+        -> \G
+    *************************** 1. row ***************************
+               id: 1
+      select_type: SIMPLE
+            table: test
+             type: ALL
+    possible_keys: value0
+              key: NULL
+          key_len: NULL
+              ref: NULL
+             rows: 6
+            Extra: Using where
+    1 row in set (0.00 sec)
 
 See bug: https://rt.cpan.org/Ticket/Display.html?id=43822
 


### PR DESCRIPTION
I noticed the explain select output was unreadable on metacpan, it should look better with this change.