### PR TITLE
fix 'create table' query to make it suitable for any kind of engine

### DIFF
--- a/t/40bit.t
+++ b/t/40bit.t
@@ -29,11 +29,7 @@ if (!MinimumVersion($dbh, '4.1')) {
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_b1"), "Drop table if exists dbd_mysql_b1";
 
-my $create = <<EOT;
-create table dbd_mysql_b1 (b bit(8)) engine=innodb;
-EOT
-
-ok ($dbh->do($create));
+ok( $dbh->do('CREATE TABLE dbd_mysql_b1 (b BIT(8))') );
 
 ok ($dbh->do("insert into dbd_mysql_b1 set b = b'11111111'"));
 ok ($dbh->do("insert into dbd_mysql_b1 set b = b'1010'"));


### PR DESCRIPTION
do not set an engine directly but leave it as default
personally I've tested it on MyISAM and all tests passed