### PR TITLE
Appveyor - continuous integration on Windows!

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+version: 1.0.{build}
+
+services:
+  - mysql
+
+install:
+  - cinst StrawberryPerl
+  - path C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - mkdir %APPVEYOR_BUILD_FOLDER%\tmp
+  - set TMPDIR=%APPVEYOR_BUILD_FOLDER%\tmp
+  - perl -V
+  - cpan App::cpanminus
+  - cpanm -q --showdeps --with-develop --with-suggests . | findstr /v "^perl\>" | cpanm -n
+  - 'echo End intall at: & time /t'
+
+build_script:
+  - perl Makefile.PL --mysql_config=c:\strawberry\c\bin\mysql_config.bat --testuser=root --testpassword=Password12!
+
+test_script:
+  - dmake test

--- a/t/55utf8mb4.t
+++ b/t/55utf8mb4.t
@@ -4,7 +4,6 @@ use warnings;
 use DBI;
 use Test::More;
 use vars qw($test_dsn $test_user $test_password);
-# use vars qw($COL_NULLABLE $COL_KEY);
 use lib 't', '.';
 require 'lib.pl';
 
@@ -15,17 +14,15 @@ if ($@) {
     plan skip_all => "no database connection";
 }
 
-if (!MinimumVersion($dbh, '5.5')) {
-    plan skip_all =>
-        "SKIP TEST: You must have MySQL version 5.5 and greater for this test to run";
-}
-plan tests => 6;
-
-$dbh = DBI->connect($test_dsn . ';mysql_enable_utf8mb4=1', $test_user, $test_password,
+$dbh = DBI->connect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
-ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t55utf8mb4");
-ok $dbh->do("CREATE TABLE dbd_mysql_t55utf8mb4 (id SERIAL, val TEXT CHARACTER SET utf8mb4)");
+eval {$dbh->do("SET NAMES 'utf8mb4'");};
+if ($@) {
+   $dbh->disconnect();
+   plan skip_all => "no support for utf8mb4";
+}
+ok $dbh->do("CREATE TEMPORARY TABLE dbd_mysql_t55utf8mb4 (id SERIAL, val TEXT CHARACTER SET utf8mb4)");
 
 my $sth = $dbh->prepare("INSERT INTO dbd_mysql_t55utf8mb4(val) VALUES('😈')");
 $sth->execute();
@@ -34,13 +31,10 @@ my $query = "SELECT val, HEX(val) FROM dbd_mysql_t55utf8mb4 LIMIT 1";
 $sth = $dbh->prepare($query) or die "$DBI::errstr";
 ok $sth->execute;
 
-my $ref;
-$ref = $sth->fetchrow_arrayref ;
-$sth->finish;
-
-ok defined $ref;
-
+ok(my $ref = $sth->fetchrow_arrayref, 'fetch row');
+ok($sth->finish, 'close sth');
 cmp_ok $ref->[0], 'eq', "😈";
 cmp_ok $ref->[1], 'eq', "F09F9888";
 
 $dbh->disconnect();
+done_testing;


### PR DESCRIPTION
I added an Appveyor configuration so we have CI testing on Windows. It's working OK but currently exposes two problems that have to do with recent additions to DBD::mysql

You can check the build log here: https://ci.appveyor.com/project/mbeijen/dbd-mysql/build/1.0.4
(this is for my repo, I'll also enable building on perl5/DBD-mysql)

1. utf8mb4 is not a supported character set. We'd have to modify the 55utf8.t file to check for availability of the character set before running the tests.

    /55utf8.t ........................... ok
    Character set 'utf8mb4' is not a compiled character set and is not specified in the 'c:\Program Files\MySQL\MySQL Server 5.1\\share\charsets\Index.xml' file
    DBI connect('test;mysql_enable_utf8mb4=1','root',...) failed: Can't initialize character set utf8mb4 (path: c:\Program Files\MySQL\MySQL Server 5.1\\share\charsets\) at t/55utf8mb4.t line 24.

2. `t/56connattr.t` fails because this feature requires an MySQL 5.6 server and 5.6 (or 5.5?) client libs as well. Currently the test runs using the MySQL 5.1 libraries which are bundled in Strawberry Perl. We should modify the tests to skip if the feature is not supported by the client libs.

Adding appveyor reveals these issues! I hope using it we can prevent similar breakage in the future.