### PR TITLE
Fix use after free error.

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2085,10 +2085,6 @@ static int my_login(pTHX_ SV* dbh, imp_dbh_t *imp_dbh)
   }
   result = mysql_dr_connect(dbh, imp_dbh->pmysql, mysql_socket, host, port, user,
 			  password, dbname, imp_dbh) ? TRUE : FALSE;
-  if (fresh && !result) {
-      /* Prevent leaks, but do not free in case of a reconnect. See #97625 */
-      Safefree(imp_dbh->pmysql);
-  }
   return result;
 }
 
@@ -2142,9 +2138,12 @@ int dbd_db_login(SV* dbh, imp_dbh_t* imp_dbh, char* dbname, char* user,
 
   if (!my_login(aTHX_ dbh, imp_dbh))
   {
-    if(imp_dbh->pmysql)
+    if(imp_dbh->pmysql) {
         do_error(dbh, mysql_errno(imp_dbh->pmysql),
                 mysql_error(imp_dbh->pmysql) ,mysql_sqlstate(imp_dbh->pmysql));
+        Safefree(imp_dbh->pmysql);
+
+    }
     return FALSE;
   }
 


### PR DESCRIPTION
When my_login fails the code tries to call mysql_errno on the mysql connection. However my_login has already free'd that connection variable, therefore causing a use-after-free error.

This patch changes that so that the free happens after the call to the error functions.

This was found with the help of Address Sanitizer.