### PR TITLE
Mention how to make the module have SSL enabled

### DIFF
--- a/lib/DBD/mysql/INSTALL.pod
+++ b/lib/DBD/mysql/INSTALL.pod
@@ -519,6 +519,26 @@ you may also try to link without gzip libraries.
 
 =back
 
+=head1 ENABLE ENCRYPTED CONNECTIONS
+
+Connecting to your servers over an encrypted connection (SSL) is easily
+accomplished by ensuring the C<--ssl> option is provided.
+
+Create an environment variable, C<DBD_MYSQL_SSL> and give it a true value.
+
+Attempting to connect to a server that requires an encrypted connection without
+first having L<DBD::mysql> installed with the C<--ssl> option will result in
+an error that makes things appear as if your password is incorrect.
+
+  export DBD_MYSQL_SSL=1
+  cpan DBD::mysql
+
+The environment variable is also honored on Windows systems.  Create the proper
+environment variable before opening your command line window and then install
+L<DBD::mysql>.
+
+  cpan DBD::mysql
+
 =head1 MARIADB NATIVE CLIENT INSTALLATION
 
 The MariaDB native client is another option for connecting to a MySQL·


### PR DESCRIPTION
I, admittedly stupidly, ran around in circles when trying to figure out why SSL connections weren't working properly on a Windows box with a brand new install of Strawberry Perl 5.22.

Going through that made me realize that I might have realized the error of my ways slightly faster if it was documented.

Thanks,
Chase