### PR TITLE
RaiseError 1 causing make test to FAIL on machines without a mysql available for testing

### DIFF
--- a/t/05dbcreate.t
+++ b/t/05dbcreate.t
@@ -11,7 +11,7 @@ require 'lib.pl';
 
 my $dbh;
 eval {$dbh= DBI->connect('DBI:mysql:', $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
+                      { RaiseError => 0, PrintError => 1, AutoCommit => 0 });};
 if ($@) {
     diag $@;
     plan skip_all => "no database connection";


### PR DESCRIPTION
I have noticed that one machines that do not have a mysql db available for testing rather than make test skipping the tests and issuing a PASS so the module will install it results in a FAIL and refuses to install without intervention.  

RaiseError => 0 does not exhibit this behavior and results in no change in behavior when there is in fact a DB available for testing.  

This will restore the ability to install DBD::mysql without having a mysql db for the tests to pass.