### PR TITLE
Add DBI back to configure_requires

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -424,7 +424,9 @@ if (eval $ExtUtils::MakeMaker::VERSION >= 5.43) {
                        'Test::Deep'   => 0,
                        'Time::HiRes'  => 0,
     },
-    CONFIGURE_REQUIRES => {'Data::Dumper' => 0},
+    CONFIGURE_REQUIRES => { 'DBI' => 1.609,
+                            'Data::Dumper' => 0,
+    },
   );
 }
 


### PR DESCRIPTION
There's `require DBI::DBD` in `Makefile.PL` which means you have to add DBI::DBD as a dependency in configure_requires, otherwise installing DBD::mysql will fail on a fresh perl install.