### PR TITLE
Add support for BIT type and coerce scalar value to correct types when mysql_server_prepare=0

### DIFF
--- a/t/rt88006-bit-prepare.t
+++ b/t/rt88006-bit-prepare.t
@@ -31,22 +31,32 @@ EOT
 
 ok $dbh->do($create),"create table for $scenario";
 
-ok $dbh->do("INSERT INTO dbd_mysql_rt88006_bit_prep (id, flags) VALUES (1, b'10'), (2, b'1')");
+ok $dbh->do("INSERT INTO dbd_mysql_rt88006_bit_prep (id, flags) VALUES (1, b'10'), (2, b'1'), (3, b'1111111111111111111111111111111111111111')");
 
 my $sth = $dbh->prepare("SELECT id,flags FROM dbd_mysql_rt88006_bit_prep WHERE id = 1");
 ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
 ok (my $r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario");
 is ($r->{id}, 1, 'id test contents');
-TODO: {
-  local $TODO = "rt88006" if $scenario eq 'prepare';
-  ok ($r->{flags}, 'flags has contents');
-}
+ok ($r->{flags}, 'flags has contents');
+ok $sth->finish;
+
+ok $sth = $dbh->prepare("SELECT id,flags FROM dbd_mysql_rt88006_bit_prep WHERE id = 3");
+ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with more then 32 bits");
+is ($r->{id}, 3, 'id test contents');
+ok ($r->{flags}, 'flags has contents');
 ok $sth->finish;
 
 ok $sth = $dbh->prepare("SELECT id,BIN(flags) FROM dbd_mysql_rt88006_bit_prep WHERE ID =1");
 ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
 ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with BIN()");
 is ($r->{id}, 1, 'id test contents');
+ok ($r->{'BIN(flags)'}, 'flags has contents');
+
+ok $sth = $dbh->prepare("SELECT id,BIN(flags) FROM dbd_mysql_rt88006_bit_prep WHERE ID =3");
+ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with BIN() and more then 32 bits");
+is ($r->{id}, 3, 'id test contents');
 ok ($r->{'BIN(flags)'}, 'flags has contents');
 
 ok $sth->finish;


### PR DESCRIPTION
Without mysql_server_prepare=1 DBD::mysql returns stringified numbers (e.g. "1") for columns of INT type. Second patch fix this problem and coerce scalars to correct perl types.

Both patches adding support for MYSQL_TYPE_BIT. When value has max 32 bits then it is stored as perl unsigned integer. Otherwise as raw string. Address bug: https://rt.cpan.org/Public/Bug/Display.html?id=88006