### PR TITLE
Add support for 64bit types when perl is compiled with 64bit support

### DIFF
--- a/dbdimp.h
+++ b/dbdimp.h
@@ -234,7 +234,7 @@ typedef struct imp_sth_fbh_st {
     char           *data;
     int            charsetnr;
     double         ddata;
-    int32_t        ldata;
+    IVTYPE         ldata;
 #if MYSQL_VERSION_ID < FIELD_CHARSETNR_VERSION
     unsigned int   flags;
 #endif


### PR DESCRIPTION
Perl's IV in scalar can store 64bit integer when perl was compiled with
64bit support (default on 64bit linux with gcc). Use this feature and
stores MYSQL_TYPE_LONGLONG and MYSQL_TYPE_BIT as integers instead strings
when possible.