### PR TITLE
MySQL 8.0 adaptions

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1901,7 +1901,7 @@ MYSQL *mysql_dr_connect(
 	    char *ca_path = NULL;
 	    char *cipher = NULL;
 	    STRLEN lna;
-#if MYSQL_VERSION_ID >= SSL_VERIFY_VERSION
+#if MYSQL_VERSION_ID >= SSL_VERIFY_VERSION && MYSQL_VERSION_ID <= SSL_LAST_VERIFY_VERSION
             /*
               New code to utilise MySQLs new feature that verifies that the
               server's hostname that the client connects to matches that of
@@ -1932,7 +1932,7 @@ MYSQL *mysql_dr_connect(
 
 	    mysql_ssl_set(sock, client_key, client_cert, ca_file,
 			  ca_path, cipher);
-#if MYSQL_VERSION_ID >= SSL_VERIFY_VERSION
+#if MYSQL_VERSION_ID >= SSL_VERIFY_VERSION && MYSQL_VERSION_ID <= SSL_LAST_VERIFY_VERSION
 	    mysql_options(sock, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_verify_true);
 #endif
 	    client_flag |= CLIENT_SSL;

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -49,6 +49,7 @@
 #define GEO_DATATYPE_VERSION 50007
 #define NEW_DATATYPE_VERSION 50003
 #define SSL_VERIFY_VERSION 50023
+#define SSL_LAST_VERIFY_VERSION 50799
 #define MYSQL_VERSION_5_0 50001
 /* This is to avoid the ugly #ifdef mess in dbdimp.c */
 #if MYSQL_VERSION_ID < SQL_STATE_VERSION
@@ -56,12 +57,12 @@
 #endif
 
 /*
- * This is the version of libmysql that starts to support
- * MySQL Fabric.
+ * This is the versions of libmysql that supports MySQL Fabric.
 */
 #define LIBMYSQL_FABRIC_VERSION 60200
+#define LIBMYSQL_LAST_FABRIC_VERSION 69999
 
-#if LIBMYSQL_VERSION_ID >= LIBMYSQL_FABRIC_VERSION
+#if LIBMYSQL_VERSION_ID >= LIBMYSQL_FABRIC_VERSION && LIBMYSQL_VERSION_ID <= LIBMYSQL_LAST_FABRIC_VERSION
 #define FABRIC_SUPPORT 1
 #else
 #define FABRIC_SUPPORT 0

--- a/mysql.xs
+++ b/mysql.xs
@@ -96,6 +96,7 @@ _admin_internal(drh,dbh,command,dbname=NULL,host=NULL,port=NULL,user=NULL,passwo
   MYSQL mysql;
   int retval;
   MYSQL* sock;
+  const char *shutdown = "SHUTDOWN";
 
   /*
    *  Connect to the database, if required.
@@ -119,7 +120,11 @@ _admin_internal(drh,dbh,command,dbname=NULL,host=NULL,port=NULL,user=NULL,passwo
 #if MYSQL_VERSION_ID < 40103
     retval = mysql_shutdown(sock);
 #else
+#if MYSQL_VERSION_ID < 50709
     retval = mysql_shutdown(sock, SHUTDOWN_DEFAULT);
+#else
+    retval = mysql_real_query(sock, shutdown, strlen(shutdown));
+#endif
 #endif
   else if (strEQ(command, "reload"))
     retval = mysql_reload(sock);


### PR DESCRIPTION
1. Changes in SSL server verification
2. MySQL library that supports fabric is 6.x.x
3. mysql_shutdown has been deprecated since 5.7.9 and is now gone