### PR TITLE
Add support for 64bit types when perl is compiled with 64bit support

### DIFF
--- a/dbdimp.h
+++ b/dbdimp.h
@@ -22,7 +22,6 @@
 #include <mysqld_error.h>  /* Comes MySQL */
 
 #include <errmsg.h> /* Comes with MySQL-devel */
-#include <stdint.h> /* For int32_t */
 
 /* For now, we hardcode this, but in the future,
  * we can detect capabilities of the MySQL libraries
@@ -214,7 +213,7 @@ typedef struct imp_sth_ph_st {
 typedef struct imp_sth_phb_st {
     union
     {
-      int32_t lval;
+      IV     lval;
       double dval;
     } numeric_val;
     unsigned long   length;
@@ -235,7 +234,7 @@ typedef struct imp_sth_fbh_st {
     char           *data;
     int            charsetnr;
     double         ddata;
-    int32_t        ldata;
+    IV             ldata;
 #if MYSQL_VERSION_ID < FIELD_CHARSETNR_VERSION
     unsigned int   flags;
 #endif

--- a/mysql.xs
+++ b/mysql.xs
@@ -444,10 +444,15 @@ do(dbh, statement, attr=Nullsv, ...)
             break;
 
           case MYSQL_TYPE_LONGLONG:
+#if IVSIZE < 8
             /* perl handles long long as double
              * so we'll set this to string */
             buffer_type= MYSQL_TYPE_STRING;
             param_type= SQL_VARCHAR;
+#else
+            buffer_type= MYSQL_TYPE_LONG;
+            param_type= SQL_BIGINT;
+#endif
             break;
 
           case MYSQL_TYPE_NEWDATE:


### PR DESCRIPTION
Perl's IV in scalar can store 64bit integer when perl was compiled with
64bit support (default on 64bit linux with gcc). Use this feature and
stores MYSQL_TYPE_LONGLONG as integers instead strings when possible.