### PR TITLE
Cherry pick & rebase old commits

### DIFF
--- a/t/rt88006-bit-prepare.t
+++ b/t/rt88006-bit-prepare.t
@@ -10,6 +10,7 @@ require 'lib.pl';
 for my $scenario (qw(prepare noprepare)) {
 
 my $dbh;
+my $sth;
 
 my $dsn = $test_dsn;
 $dsn .= ';mysql_server_prepare=1;' if $scenario eq 'prepare';
@@ -23,7 +24,7 @@ if ($@) {
 my $create = <<EOT;
 CREATE TEMPORARY TABLE `dbd_mysql_rt88006_bit_prep` (
   `id` bigint(20) NOT NULL auto_increment,
-  `flags` bit(32) NOT NULL,
+  `flags` bit(40) NOT NULL,
   PRIMARY KEY  (`id`),
   KEY `flags` (`flags`)
 )
@@ -31,23 +32,52 @@ EOT
 
 ok $dbh->do($create),"create table for $scenario";
 
-ok $dbh->do("INSERT INTO dbd_mysql_rt88006_bit_prep (id, flags) VALUES (1, b'10'), (2, b'1')");
+ok $dbh->do("INSERT INTO dbd_mysql_rt88006_bit_prep (id, flags) VALUES (1, b'10'), (2, b'1'), (3, b'1111011111101111101101111111101111111101')");
 
-my $sth = $dbh->prepare("SELECT id,flags FROM dbd_mysql_rt88006_bit_prep WHERE id = 1");
+ok $sth = $dbh->prepare("INSERT INTO dbd_mysql_rt88006_bit_prep (id, flags) VALUES (?, ?)");
+ok $sth->bind_param(1, 4, DBI::SQL_INTEGER);
+ok $sth->bind_param(2, pack("B*", '1110000000000000011101100000000011111101'), DBI::SQL_BINARY);
+ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok $sth->finish;
+
+ok $sth = $dbh->prepare("SELECT id,flags FROM dbd_mysql_rt88006_bit_prep WHERE id = 1");
 ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
 ok (my $r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario");
 is ($r->{id}, 1, 'id test contents');
-TODO: {
-  local $TODO = "rt88006" if $scenario eq 'prepare';
-  ok ($r->{flags}, 'flags has contents');
-}
+is (unpack("B*", $r->{flags}), '0000000000000000000000000000000000000010', 'flags has contents');
+ok $sth->finish;
+
+ok $sth = $dbh->prepare("SELECT id,flags FROM dbd_mysql_rt88006_bit_prep WHERE id = 3");
+ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with more then 32 bits");
+is ($r->{id}, 3, 'id test contents');
+is (unpack("B*", $r->{flags}), '1111011111101111101101111111101111111101', 'flags has contents');
+ok $sth->finish;
+
+ok $sth = $dbh->prepare("SELECT id,flags FROM dbd_mysql_rt88006_bit_prep WHERE id = 4");
+ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with binary insert");
+is ($r->{id}, 4, 'id test contents');
+is (unpack("B*", $r->{flags}), '1110000000000000011101100000000011111101', 'flags has contents');
 ok $sth->finish;
 
 ok $sth = $dbh->prepare("SELECT id,BIN(flags) FROM dbd_mysql_rt88006_bit_prep WHERE ID =1");
 ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
 ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with BIN()");
 is ($r->{id}, 1, 'id test contents');
-ok ($r->{'BIN(flags)'}, 'flags has contents');
+is ($r->{'BIN(flags)'}, '10', 'flags has contents');
+
+ok $sth = $dbh->prepare("SELECT id,BIN(flags) FROM dbd_mysql_rt88006_bit_prep WHERE ID =3");
+ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with BIN() and more then 32 bits");
+is ($r->{id}, 3, 'id test contents');
+is ($r->{'BIN(flags)'}, '1111011111101111101101111111101111111101', 'flags has contents');
+
+ok $sth = $dbh->prepare("SELECT id,BIN(flags) FROM dbd_mysql_rt88006_bit_prep WHERE ID =4");
+ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with BIN() and with binary insert");
+is ($r->{id}, 4, 'id test contents');
+is ($r->{'BIN(flags)'}, '1110000000000000011101100000000011111101', 'flags has contents');
 
 ok $sth->finish;
 ok $dbh->disconnect;


### PR DESCRIPTION
* Add support for fetching columns of BIT type with mysql_server_prepare=1
* Correctly coerce fetched scalar values when mysql_server_prepare is not used

Patch for BIT type is slightly different as in https://github.com/perl5-dbi/DBD-mysql/pull/53 but backward compatible with current version of DBD::mysql and mysql_server_prepare=0