### PR TITLE
Fix support for mysql_enable_utf8 and mysql_enable_utf8mb4

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2870,14 +2870,16 @@ SV* dbd_db_FETCH_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv)
  *
  **************************************************************************/
 int
-dbd_st_prepare(
+dbd_st_prepare_sv(
   SV *sth,
   imp_sth_t *imp_sth,
-  char *statement,
+  SV *statement_sv,
   SV *attribs)
 {
   int i;
   SV **svp;
+  char *statement;
+  STRLEN statement_len;
   dTHX;
 #if MYSQL_VERSION_ID >= SERVER_PREPARE_VERSION
 #if MYSQL_VERSION_ID < CALL_PLACEHOLDER_VERSION
@@ -2892,6 +2894,8 @@ dbd_st_prepare(
 #endif
   D_imp_xxh(sth);
   D_imp_dbh_from_sth;
+
+  statement = SvPV(statement_sv, statement_len);
 
   if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
     PerlIO_printf(DBIc_LOGPIO(imp_xxh),
@@ -2975,7 +2979,7 @@ dbd_st_prepare(
 #else
                     "\t\tneed to test for restrictions\n");
 #endif
-    str_last_ptr = statement + strlen(statement);
+    str_last_ptr = statement + statement_len;
     for (str_ptr= statement; str_ptr < str_last_ptr; str_ptr++)
     {
 #if MYSQL_VERSION_ID < LIMIT_PLACEHOLDER_VERSION
@@ -3071,7 +3075,7 @@ dbd_st_prepare(
 
     prepare_retval= mysql_stmt_prepare(imp_sth->stmt,
                                        statement,
-                                       strlen(statement));
+                                       statement_len);
     if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
         PerlIO_printf(DBIc_LOGPIO(imp_xxh),
                       "\t\tmysql_stmt_prepare returned %d\n",

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -336,77 +336,141 @@ free_param(pTHX_ imp_sth_ph_t *params, int num_params)
   }
 }
 
+enum perl_type {
+  PERL_TYPE_UNDEF,
+  PERL_TYPE_INTEGER,
+  PERL_TYPE_NUMERIC,
+  PERL_TYPE_BINARY,
+  PERL_TYPE_STRING
+};
+
 /* 
   Convert a MySQL type to a type that perl can handle
-
-  NOTE: In the future we may want to return a struct with a lot of
-  information for each type
 */
-
-static enum enum_field_types mysql_to_perl_type(enum enum_field_types type)
+static enum perl_type mysql_to_perl_type(enum enum_field_types type)
 {
-  static enum enum_field_types enum_type;
-
   switch (type) {
-  case MYSQL_TYPE_DOUBLE:
-  case MYSQL_TYPE_FLOAT:
-    enum_type= MYSQL_TYPE_DOUBLE;
-    break;
+  case MYSQL_TYPE_NULL:
+    return PERL_TYPE_UNDEF;
 
-  case MYSQL_TYPE_SHORT:
   case MYSQL_TYPE_TINY:
-  case MYSQL_TYPE_LONG:
+  case MYSQL_TYPE_SHORT:
   case MYSQL_TYPE_INT24:
-  case MYSQL_TYPE_YEAR:
+  case MYSQL_TYPE_LONG:
 #if IVSIZE >= 8
   case MYSQL_TYPE_LONGLONG:
-    enum_type= MYSQL_TYPE_LONGLONG;
-#else
-    enum_type= MYSQL_TYPE_LONG;
 #endif
-    break;
+  case MYSQL_TYPE_YEAR:
+    return PERL_TYPE_INTEGER;
+
+  case MYSQL_TYPE_FLOAT:
+#if NVSIZE >= 8
+  case MYSQL_TYPE_DOUBLE:
+#endif
+    return PERL_TYPE_NUMERIC;
 
 #if MYSQL_VERSION_ID > NEW_DATATYPE_VERSION
   case MYSQL_TYPE_BIT:
-    enum_type= MYSQL_TYPE_BIT;
-    break;
 #endif
-
-#if MYSQL_VERSION_ID > NEW_DATATYPE_VERSION
-  case MYSQL_TYPE_NEWDECIMAL:
-#endif
-  case MYSQL_TYPE_DECIMAL:
-    enum_type= MYSQL_TYPE_DECIMAL;
-    break;
-
-#if IVSIZE < 8
-  case MYSQL_TYPE_LONGLONG:
-#endif
-  case MYSQL_TYPE_DATE:
-  case MYSQL_TYPE_TIME:
-  case MYSQL_TYPE_DATETIME:
-  case MYSQL_TYPE_NEWDATE:
-  case MYSQL_TYPE_TIMESTAMP:
-  case MYSQL_TYPE_VAR_STRING:
-#if MYSQL_VERSION_ID > NEW_DATATYPE_VERSION
-  case MYSQL_TYPE_VARCHAR:
-#endif
-  case MYSQL_TYPE_STRING:
-    enum_type= MYSQL_TYPE_STRING;
-    break;
-
 #if MYSQL_VERSION_ID > GEO_DATATYPE_VERSION
   case MYSQL_TYPE_GEOMETRY:
 #endif
-  case MYSQL_TYPE_BLOB:
   case MYSQL_TYPE_TINY_BLOB:
-    enum_type= MYSQL_TYPE_BLOB;
-    break;
+  case MYSQL_TYPE_BLOB:
+  case MYSQL_TYPE_MEDIUM_BLOB:
+  case MYSQL_TYPE_LONG_BLOB:
+    return PERL_TYPE_BINARY;
 
   default:
-    enum_type= MYSQL_TYPE_STRING;    /* MySQL can handle all types as strings */
+    return PERL_TYPE_STRING;
   }
-  return(enum_type);
+}
+
+#if MYSQL_VERSION_ID >= SERVER_PREPARE_VERSION
+/*
+  Convert a DBI SQL type to a MySQL type for prepared statement storage
+  See: http://dev.mysql.com/doc/refman/5.7/en/c-api-prepared-statement-type-codes.html
+*/
+static enum enum_field_types sql_to_mysql_type(IV sql_type)
+{
+  switch (sql_type) {
+  case SQL_BOOLEAN:
+  case SQL_TINYINT:
+    return MYSQL_TYPE_TINY;
+  case SQL_SMALLINT:
+    return MYSQL_TYPE_SHORT;
+  case SQL_INTEGER:
+    return MYSQL_TYPE_LONG;
+  case SQL_BIGINT:
+    return MYSQL_TYPE_LONGLONG;
+
+  case SQL_FLOAT:
+    return MYSQL_TYPE_FLOAT;
+  case SQL_DOUBLE:
+  case SQL_REAL:
+    return MYSQL_TYPE_DOUBLE;
+
+  /* TODO: datetime structures */
+#if 0
+  case SQL_TIME:
+    return MYSQL_TYPE_TIME;
+  case SQL_DATE:
+    return MYSQL_TYPE_DATE;
+  case SQL_DATETIME:
+    return MYSQL_TYPE_DATETIME;
+  case SQL_TIMESTAMP:
+    return MYSQL_TYPE_TIMESTAMP;
+#endif
+
+  case SQL_BIT:
+  case SQL_BLOB:
+  case SQL_BINARY:
+  case SQL_VARBINARY:
+  case SQL_LONGVARBINARY:
+    return MYSQL_TYPE_BLOB;
+
+  default:
+    return MYSQL_TYPE_STRING;
+  }
+}
+
+/*
+  Returns true if MySQL type for prepared statement storage uses dynamically allocated buffer
+*/
+static bool mysql_type_has_allocated_buffer(enum enum_field_types type)
+{
+  switch (type) {
+  case MYSQL_TYPE_STRING:
+  case MYSQL_TYPE_BLOB:
+    return true;
+
+  default:
+    return false;
+  }
+}
+#endif
+
+/*
+  Returns true if DBI SQL type represents numeric value (regardless of how is stored)
+*/
+static bool sql_type_is_numeric(IV sql_type)
+{
+  switch (sql_type) {
+  case SQL_BOOLEAN:
+  case SQL_TINYINT:
+  case SQL_SMALLINT:
+  case SQL_INTEGER:
+  case SQL_BIGINT:
+  case SQL_FLOAT:
+  case SQL_DOUBLE:
+  case SQL_REAL:
+  case SQL_NUMERIC:
+  case SQL_DECIMAL:
+    return true;
+
+  default:
+    return false;
+  }
 }
 
 #if defined(DBD_MYSQL_EMBEDDED)
@@ -748,20 +812,7 @@ static char *parse_params(
           valbuf= SvPV(ph->value, vallen);
           if (valbuf)
           {
-            switch (ph->type)
-            {
-              case SQL_NUMERIC:
-              case SQL_DECIMAL:
-              case SQL_INTEGER:
-              case SQL_SMALLINT:
-              case SQL_FLOAT:
-              case SQL_REAL:
-              case SQL_DOUBLE:
-              case SQL_BIGINT:
-              case SQL_TINYINT:
-                is_num = TRUE;
-                break;
-            }
+            is_num = sql_type_is_numeric(ph->type);
 
             /* (note this sets *end, which we use if is_num) */
             if ( parse_number(valbuf, vallen, &end) != 0 && is_num)
@@ -980,9 +1031,9 @@ static const sql_type_info_t SQL_GET_TYPE_INFO_values[]= {
     0, 0, 10,
     SQL_SMALLINT, 0, 0,
 #if MYSQL_VERSION_ID < MYSQL_VERSION_5_0
-    FIELD_TYPE_YEAR,        0
+    FIELD_TYPE_YEAR,        1
 #else
-    MYSQL_TYPE_YEAR,     0
+    MYSQL_TYPE_YEAR,     1
 #endif
   },
   { "date", SQL_DATE, 10, "'",  "'",  NULL,
@@ -1211,11 +1262,13 @@ static const sql_type_info_t SQL_GET_TYPE_INFO_values[]= {
   },
 
   { "bit", SQL_BIT, 1, NULL, NULL, NULL,
-    1, 0, 3, 0, 0, 0, "char(1)", 0, 0, 0,
+    1, 0, 3, 0, 0, 0, "bit", 0, 0, 0,
 #if MYSQL_VERSION_ID < MYSQL_VERSION_5_0
     SQL_BIT, 0, 0, FIELD_TYPE_TINY, 0
-#else
+#elif MYSQL_VERSION_ID < NEW_DATATYPE_VERSION
     SQL_BIT, 0, 0, MYSQL_TYPE_TINY, 0
+#else
+    SQL_BIT, 0, 0, MYSQL_TYPE_BIT, 0
 #endif
   },
 
@@ -1303,18 +1356,25 @@ static const sql_type_info_t SQL_GET_TYPE_INFO_values[]= {
   { "bigint auto_increment", SQL_BIGINT, 19, NULL, NULL, NULL,
     0, 0, 3, 0, 0, 1, "bigint auto_increment", 0, 0, 10,
 #if MYSQL_VERSION_ID < MYSQL_VERSION_5_0
-    SQL_BIGINT, 0, 0, FIELD_TYPE_LONGLONG, 1
+    SQL_BIGINT, 0, 0, FIELD_TYPE_LONGLONG,
 #else
-    SQL_BIGINT, 0, 0, MYSQL_TYPE_LONGLONG, 1
+    SQL_BIGINT, 0, 0, MYSQL_TYPE_LONGLONG,
+#endif
+#if IVSIZE < 8
+    0
+#else
+    1
 #endif
   },
 
   { "bit auto_increment", SQL_BIT, 1, NULL, NULL, NULL,
-    0, 0, 3, 0, 0, 1, "char(1) auto_increment", 0, 0, 0,
+    0, 0, 3, 0, 0, 1, "bit auto_increment", 0, 0, 0,
 #if MYSQL_VERSION_ID < MYSQL_VERSION_5_0
-    SQL_BIT, 0, 0, FIELD_TYPE_TINY, 1
+    SQL_BIT, 0, 0, FIELD_TYPE_TINY, 0
+#elif MYSQL_VERSION_ID < NEW_DATATYPE_VERSION
+    SQL_BIT, 0, 0, MYSQL_TYPE_TINY, 0
 #else
-    SQL_BIT, 0, 0, MYSQL_TYPE_TINY, 1
+    SQL_BIT, 0, 0, MYSQL_TYPE_BIT, 0
 #endif
   },
 
@@ -1358,9 +1418,14 @@ static const sql_type_info_t SQL_GET_TYPE_INFO_values[]= {
   { "bigint unsigned auto_increment", SQL_BIGINT, 20, NULL, NULL, NULL,
     0, 0, 3, 1, 0, 1, "bigint unsigned auto_increment", 0, 0, 10,
 #if MYSQL_VERSION_ID < MYSQL_VERSION_5_0
-    SQL_BIGINT, 0, 0, FIELD_TYPE_LONGLONG, 1
+    SQL_BIGINT, 0, 0, FIELD_TYPE_LONGLONG,
 #else
-    SQL_BIGINT, 0, 0, MYSQL_TYPE_LONGLONG, 1
+    SQL_BIGINT, 0, 0, MYSQL_TYPE_LONGLONG,
+#endif
+#if IVSIZE < 8
+    0
+#else
+    1
 #endif
   },
 
@@ -3541,7 +3606,6 @@ my_ulonglong mysql_st_internal_execute41(
                                         )
 {
   int i;
-  enum enum_field_types enum_type;
   dTHX;
   int execute_retval;
   my_ulonglong rows=0;
@@ -3603,15 +3667,14 @@ my_ulonglong mysql_st_internal_execute41(
   */
   else
   {
-    for (i = mysql_stmt_field_count(stmt) - 1; i >=0; --i) {
-        enum_type = mysql_to_perl_type(stmt->fields[i].type);
-        if (enum_type != MYSQL_TYPE_DOUBLE && enum_type != MYSQL_TYPE_LONG && enum_type != MYSQL_TYPE_LONGLONG && enum_type != MYSQL_TYPE_BIT)
-        {
-            /* mysql_stmt_store_result to update MYSQL_FIELD->max_length */
-            my_bool on = 1;
-            mysql_stmt_attr_set(stmt, STMT_ATTR_UPDATE_MAX_LENGTH, &on);
-            break;
-        }
+    for (i = mysql_stmt_field_count(stmt) - 1; i >=0; --i)
+    {
+      if (mysql_type_has_allocated_buffer(stmt->fields[i].type))
+      {
+        /* mysql_stmt_store_result to update MYSQL_FIELD->max_length */
+        my_bool on = 1;
+        mysql_stmt_attr_set(stmt, STMT_ATTR_UPDATE_MAX_LENGTH, &on);
+      }
     }
     /* Get the total rows affected and return */
     if (mysql_stmt_store_result(stmt))
@@ -3829,7 +3892,6 @@ int dbd_describe(SV* sth, imp_sth_t* imp_sth)
   if (imp_sth->use_server_side_prepare)
   {
     int i;
-    int col_type;
     int num_fields= DBIc_NUM_FIELDS(imp_sth);
     imp_sth_fbh_t *fbh;
     MYSQL_BIND *buffer;
@@ -3869,27 +3931,29 @@ int dbd_describe(SV* sth, imp_sth_t* imp_sth)
          i++, fbh++, buffer++
         )
     {
-      /* get the column type */
-      col_type = fields ? fields[i].type : MYSQL_TYPE_STRING;
-
       if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
       {
-        PerlIO_printf(DBIc_LOGPIO(imp_xxh),"\t\ti %d col_type %d fbh->length %lu\n",
-                      i, col_type, fbh->length);
+        PerlIO_printf(DBIc_LOGPIO(imp_xxh),"\t\ti %d fbh->length %lu\n",
+                      i, fbh->length);
+#if MYSQL_VERSION_ID < FIELD_CHARSETNR_VERSION
+        PerlIO_printf(DBIc_LOGPIO(imp_xxh),
+                      "\t\tfields[i].length %lu fields[i].max_length %lu fields[i].type %d fields[i].charsetnr %d\n",
+                      fields[i].length, fields[i].max_length, fields[i].type);
+#else
         PerlIO_printf(DBIc_LOGPIO(imp_xxh),
                       "\t\tfields[i].length %lu fields[i].max_length %lu fields[i].type %d fields[i].charsetnr %d\n",
                       fields[i].length, fields[i].max_length, fields[i].type,
                       fields[i].charsetnr);
+#endif
       }
-      fbh->charsetnr = fields[i].charsetnr;
 #if MYSQL_VERSION_ID < FIELD_CHARSETNR_VERSION 
       fbh->flags     = fields[i].flags;
+#else
+      fbh->charsetnr = fields[i].charsetnr;
 #endif
 
-      buffer->buffer_type= mysql_to_perl_type(col_type);
-      if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-        PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tmysql_to_perl_type returned %d\n",
-                      col_type);
+      buffer->buffer_type= fields[i].type;
+      buffer->is_unsigned= (fields[i].flags & UNSIGNED_FLAG) ? 1 : 0;
       buffer->length= &(fbh->length);
       buffer->is_null= (my_bool*) &(fbh->is_null);
       buffer->error= (my_bool*) &(fbh->error);
@@ -3898,28 +3962,56 @@ int dbd_describe(SV* sth, imp_sth_t* imp_sth)
         buffer->buffer_type = MYSQL_TYPE_STRING;
 
       switch (buffer->buffer_type) {
-      case MYSQL_TYPE_DOUBLE:
-        buffer->buffer_length= sizeof(fbh->ddata);
-        buffer->buffer= (char*) &fbh->ddata;
+      case MYSQL_TYPE_NULL:
+        buffer->buffer_length= 0;
+        buffer->buffer= NULL;
+
+      case MYSQL_TYPE_TINY:
+        buffer->buffer_length= sizeof(fbh->numeric_val.tval);
+        buffer->buffer= (char*) &fbh->numeric_val.tval;
+        break;
+
+      case MYSQL_TYPE_SHORT:
+        buffer->buffer_length= sizeof(fbh->numeric_val.sval);
+        buffer->buffer= (char*) &fbh->numeric_val.sval;
         break;
 
       case MYSQL_TYPE_LONG:
-      case MYSQL_TYPE_LONGLONG:
-        buffer->buffer_length= sizeof(fbh->ldata);
-        buffer->buffer= (char*) &fbh->ldata;
-        buffer->is_unsigned= (fields[i].flags & UNSIGNED_FLAG) ? 1 : 0;
+        buffer->buffer_length= sizeof(fbh->numeric_val.lval);
+        buffer->buffer= (char*) &fbh->numeric_val.lval;
         break;
 
-      case MYSQL_TYPE_BIT:
-        buffer->buffer_length= 8;
-        Newz(908, fbh->data, buffer->buffer_length, char);
-        buffer->buffer= (char *) fbh->data;
+      case MYSQL_TYPE_LONGLONG:
+        buffer->buffer_length= sizeof(fbh->numeric_val.llval);
+        buffer->buffer= (char*) &fbh->numeric_val.llval;
         break;
+
+      case MYSQL_TYPE_FLOAT:
+        buffer->buffer_length= sizeof(fbh->numeric_val.fval);
+        buffer->buffer= (char*) &fbh->numeric_val.fval;
+        break;
+
+      case MYSQL_TYPE_DOUBLE:
+        buffer->buffer_length= sizeof(fbh->numeric_val.dval);
+        buffer->buffer= (char*) &fbh->numeric_val.dval;
+        break;
+
+      /* TODO: datetime structures */
+#if 0
+      case MYSQL_TYPE_TIME:
+      case MYSQL_TYPE_DATE:
+      case MYSQL_TYPE_DATETIME:
+      case MYSQL_TYPE_TIMESTAMP:
+        break;
+#endif
 
       default:
+        if (buffer->buffer_type != MYSQL_TYPE_BLOB)
+          buffer->buffer_type= MYSQL_TYPE_STRING;
         buffer->buffer_length= fields[i].max_length ? fields[i].max_length : 1;
         Newz(908, fbh->data, buffer->buffer_length, char);
         buffer->buffer= (char *) fbh->data;
+        break;
       }
     }
 
@@ -3970,6 +4062,8 @@ dbd_st_fetch(SV *sth, imp_sth_t* imp_sth)
   D_imp_xxh(sth);
 #if MYSQL_VERSION_ID >=SERVER_PREPARE_VERSION
   MYSQL_BIND *buffer;
+  IV int_val;
+  const char *int_type;
 #endif
   MYSQL_FIELD *fields;
   if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
@@ -4095,7 +4189,7 @@ process:
            in dbd_describe() for data. Here we know real size of field
            so we should increase buffer size and refetch column value
         */
-        if (fbh->length > buffer->buffer_length || fbh->error)
+        if (mysql_type_has_allocated_buffer(buffer->buffer_type) && (fbh->length > buffer->buffer_length || fbh->error))
         {
           if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
             PerlIO_printf(DBIc_LOGPIO(imp_xxh),
@@ -4137,35 +4231,113 @@ process:
           }
         }
 
-        /* This does look a lot like Georg's PHP driver doesn't it?  --Brian */
-        /* Credit due to Georg - mysqli_api.c  ;) --PMG */
         switch (buffer->buffer_type) {
+        case MYSQL_TYPE_TINY:
+        case MYSQL_TYPE_SHORT:
+        case MYSQL_TYPE_LONG:
+#if IVSIZE >= 8
+        case MYSQL_TYPE_LONGLONG:
+#endif
+          switch (buffer->buffer_type) {
+          case MYSQL_TYPE_TINY:
+            if (buffer->is_unsigned)
+              int_val= (unsigned char)fbh->numeric_val.tval;
+            else
+              int_val= (signed char)fbh->numeric_val.tval;
+            int_type= "TINY INT";
+            break;
+
+          case MYSQL_TYPE_SHORT:
+            if (buffer->is_unsigned)
+              int_val= (unsigned short)fbh->numeric_val.sval;
+            else
+              int_val= (signed short)fbh->numeric_val.sval;
+            int_type= "SHORT INT";
+            break;
+
+          case MYSQL_TYPE_LONG:
+            if (buffer->is_unsigned)
+              int_val= (uint32_t)fbh->numeric_val.lval;
+            else
+              int_val= (int32_t)fbh->numeric_val.lval;
+            int_type= "LONG INT";
+            break;
+
+#if IVSIZE >= 8
+          case MYSQL_TYPE_LONGLONG:
+            if (buffer->is_unsigned)
+              int_val= fbh->numeric_val.llval;
+            else
+              int_val= fbh->numeric_val.llval;
+            int_type= "LONGLONG INT";
+            break;
+#endif
+          }
+
+          if (buffer->is_unsigned)
+            sv_setuv(sv, (UV)int_val);
+          else
+            sv_setiv(sv, (IV)int_val);
+
+          if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+          {
+            if (buffer->is_unsigned)
+              PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tst_fetch AN UNSIGNED %s NUMBER %"UVuf"\n",
+                            int_type, (UV)int_val);
+            else
+              PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tst_fetch A SIGNED %s NUMBER %"IVdf"\n",
+                            int_type, (IV)int_val);
+          }
+          break;
+
+#if IVSIZE < 8
+        case MYSQL_TYPE_LONGLONG:
+          {
+            char buf[64];
+            STRLEN len = sizeof(buf);
+            char *ptr;
+
+            if (buffer->is_unsigned)
+              ptr = my_ulonglong2str(fbh->numeric_val.llval, buf, &len);
+            else
+              ptr = signed_my_ulonglong2str(fbh->numeric_val.llval, buf, &len);
+
+            sv_setpvn(sv, ptr, len);
+
+            if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+              PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tst_fetch %s LONGLONG INT NUMBER %s\n",
+                            (buffer->is_unsigned ? "AN UNSIGNED" : "A SIGNED"), ptr);
+          }
+          break;
+#endif
+
+        case MYSQL_TYPE_FLOAT:
+          if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+            PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tst_fetch A FLOAT NUMBER %f\n", fbh->numeric_val.fval);
+          sv_setnv(sv, fbh->numeric_val.fval);
+          break;
+
         case MYSQL_TYPE_DOUBLE:
           if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-            PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tst_fetch double data %f\n", fbh->ddata);
-          sv_setnv(sv, fbh->ddata);
+            PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tst_fetch A DOUBLE NUMBER %f\n", fbh->numeric_val.dval);
+          sv_setnv(sv, fbh->numeric_val.dval);
           break;
 
-        case MYSQL_TYPE_LONG:
-        case MYSQL_TYPE_LONGLONG:
-          if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-            PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tst_fetch int data %"IVdf", unsigned? %d\n",
-                          fbh->ldata, buffer->is_unsigned);
-          if (buffer->is_unsigned)
-            sv_setuv(sv, fbh->ldata);
-          else
-            sv_setiv(sv, fbh->ldata);
-
+        /* TODO: datetime structures */
+  #if 0
+        case MYSQL_TYPE_TIME:
+        case MYSQL_TYPE_DATE:
+        case MYSQL_TYPE_DATETIME:
+        case MYSQL_TYPE_TIMESTAMP:
           break;
+  #endif
 
-        case MYSQL_TYPE_BIT:
-          sv_setpvn(sv, fbh->data, fbh->length);
-
+        case MYSQL_TYPE_NULL:
+          (void) SvOK_off(sv);  /*  Field is NULL, return undef  */
           break;
 
         default:
-          if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-            PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tERROR IN st_fetch_string");
+          /* TEXT columns can be returned as MYSQL_TYPE_BLOB, so always check for charset */
           len= fbh->length;
 	  /* ChopBlanks server-side prepared statement */
           if (ChopBlanks)
@@ -4195,9 +4367,7 @@ process:
 #endif
 	/* END OF UTF8 */
           break;
-
         }
-
       }
     }
 
@@ -4303,7 +4473,7 @@ process:
         sv_setpvn(sv, col, len);
 
         switch (mysql_to_perl_type(fields[i].type)) {
-        case MYSQL_TYPE_DOUBLE:
+        case PERL_TYPE_NUMERIC:
           if (!(fields[i].flags & ZEROFILL_FLAG))
           {
             /* Coerce to dobule and set scalar as NV */
@@ -4312,8 +4482,7 @@ process:
           }
           break;
 
-        case MYSQL_TYPE_LONG:
-        case MYSQL_TYPE_LONGLONG:
+        case PERL_TYPE_INTEGER:
           if (!(fields[i].flags & ZEROFILL_FLAG))
           {
             /* Coerce to integer and set scalar as UV resp. IV */
@@ -4330,13 +4499,13 @@ process:
           }
           break;
 
-#if MYSQL_VERSION_ID > NEW_DATATYPE_VERSION
-        case MYSQL_TYPE_BIT:
-          /* Let it as binary string */
+        case PERL_TYPE_UNDEF:
+          /* Field is NULL, return undef */
+          (void) SvOK_off(sv);
           break;
-#endif
 
         default:
+          /* TEXT columns can be returned as MYSQL_TYPE_BLOB, so always check for charset */
 	/* UTF8 */
         /*HELMUT*/
 #if defined(sv_utf8_decode) && MYSQL_VERSION_ID >=SERVER_PREPARE_VERSION
@@ -4975,6 +5144,8 @@ int dbd_bind_ph(SV *sth, imp_sth_t *imp_sth, SV *param, SV *value,
   int buffer_is_unsigned= 0;
   int buffer_length= 0;
   unsigned int buffer_type= 0;
+  IV int_val= 0;
+  const char *int_type = "";
 #endif
 
   D_imp_dbh_from_sth;
@@ -4997,14 +5168,7 @@ int dbd_bind_ph(SV *sth, imp_sth_t *imp_sth, SV *param, SV *value,
      This fixes the bug whereby no warning was issued upon binding a
      defined non-numeric as numeric
    */
-  if (SvOK(value) &&
-      (sql_type == SQL_NUMERIC  ||
-       sql_type == SQL_DECIMAL  ||
-       sql_type == SQL_INTEGER  ||
-       sql_type == SQL_SMALLINT ||
-       sql_type == SQL_FLOAT    ||
-       sql_type == SQL_REAL     ||
-       sql_type == SQL_DOUBLE) )
+  if (SvOK(value) && sql_type_is_numeric(sql_type))
   {
     if (! looks_like_number(value))
     {
@@ -5026,111 +5190,191 @@ int dbd_bind_ph(SV *sth, imp_sth_t *imp_sth, SV *param, SV *value,
 #if MYSQL_VERSION_ID >= SERVER_PREPARE_VERSION
   if (imp_sth->use_server_side_prepare)
   {
-      switch(sql_type) {
-      case SQL_NUMERIC:
-      case SQL_INTEGER:
-      case SQL_SMALLINT:
-      case SQL_TINYINT:
+    buffer_is_null = !SvOK(imp_sth->params[idx].value);
+    if (!buffer_is_null) {
+      buffer_type= sql_to_mysql_type(sql_type);
+      switch (buffer_type) {
+      case MYSQL_TYPE_TINY:
+      case MYSQL_TYPE_SHORT:
+      case MYSQL_TYPE_LONG:
 #if IVSIZE >= 8
-      case SQL_BIGINT:
-          buffer_type= MYSQL_TYPE_LONGLONG;
-#else
-          buffer_type= MYSQL_TYPE_LONG;
+      case MYSQL_TYPE_LONGLONG:
 #endif
-          break;
-      case SQL_DOUBLE:
-      case SQL_DECIMAL: 
-      case SQL_FLOAT: 
-      case SQL_REAL:
-          buffer_type= MYSQL_TYPE_DOUBLE;
-          break;
-      case SQL_CHAR: 
-      case SQL_VARCHAR: 
-      case SQL_DATE: 
-      case SQL_TIME: 
-      case SQL_TIMESTAMP: 
-      case SQL_LONGVARCHAR: 
-      case SQL_BINARY: 
-      case SQL_VARBINARY: 
-      case SQL_LONGVARBINARY:
-          buffer_type= MYSQL_TYPE_BLOB;
-          break;
-      default:
-          buffer_type= MYSQL_TYPE_STRING;
-    }
-    buffer_is_null = !(SvOK(imp_sth->params[idx].value) && imp_sth->params[idx].value);
-    if (! buffer_is_null) {
-      switch(buffer_type) {
-        case MYSQL_TYPE_LONG:
-        case MYSQL_TYPE_LONGLONG:
-          /* INT */
-          if (!SvIOK(imp_sth->params[idx].value) && DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-            PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tTRY TO BIND AN INT NUMBER\n");
-          buffer_length = sizeof imp_sth->fbind[idx].numeric_val.lval;
-          imp_sth->fbind[idx].numeric_val.lval= SvIV(imp_sth->params[idx].value);
-          buffer=(void*)&(imp_sth->fbind[idx].numeric_val.lval);
-          if (!SvIOK(imp_sth->params[idx].value))
-          {
-            if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-              PerlIO_printf(DBIc_LOGPIO(imp_xxh),
-                            "   Conversion to INT NUMBER was not successful -> '%s' --> (unsigned) '%"UVuf"' / (signed) '%"IVdf"' <- fallback to STRING\n",
-                            SvPV_nolen(imp_sth->params[idx].value), imp_sth->fbind[idx].numeric_val.lval, imp_sth->fbind[idx].numeric_val.lval);
-            buffer_type = MYSQL_TYPE_STRING;
-            break;
-          }
-          if (SvIsUV(imp_sth->params[idx].value))
+        if (!SvIOK(imp_sth->params[idx].value) && DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+          PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tTRY TO BIND AN INT NUMBER\n");
+        int_val= SvIV(imp_sth->params[idx].value);
+        if (SvIsUV(imp_sth->params[idx].value))
+          buffer_is_unsigned= 1;
+
+        switch (buffer_type) {
+        case MYSQL_TYPE_TINY:
+          buffer_length= sizeof(imp_sth->fbind[idx].numeric_val.tval);
+          if (int_val > SCHAR_MAX)
             buffer_is_unsigned= 1;
-          if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-            PerlIO_printf(DBIc_LOGPIO(imp_xxh),
-                          "   SCALAR type %"IVdf" ->%"IVdf"<- IS A INT NUMBER\n",
-                          sql_type, *(IV *)buffer);
+          if (buffer_is_unsigned)
+            imp_sth->fbind[idx].numeric_val.tval= (unsigned char)((UV)int_val);
+          else
+            imp_sth->fbind[idx].numeric_val.tval= (signed char)((IV)int_val);
+          buffer= (void*)&(imp_sth->fbind[idx].numeric_val.tval);
+          int_val= imp_sth->fbind[idx].numeric_val.tval;
+          int_type= "TINY INT";
           break;
 
-        case MYSQL_TYPE_DOUBLE:
-          if (!SvNOK(imp_sth->params[idx].value) && DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-            PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tTRY TO BIND A FLOAT NUMBER\n");
-          buffer_length = sizeof imp_sth->fbind[idx].numeric_val.dval;
-          imp_sth->fbind[idx].numeric_val.dval= SvNV(imp_sth->params[idx].value);
-          buffer=(char*)&(imp_sth->fbind[idx].numeric_val.dval);
-          if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-            PerlIO_printf(DBIc_LOGPIO(imp_xxh),
-                          "   SCALAR type %"IVdf" ->%f<- IS A FLOAT NUMBER\n",
-                          sql_type, (double)(*buffer));
+        case MYSQL_TYPE_SHORT:
+          buffer_length= sizeof(imp_sth->fbind[idx].numeric_val.sval);
+          if (int_val > SHRT_MAX)
+            buffer_is_unsigned= 1;
+          if (buffer_is_unsigned)
+            imp_sth->fbind[idx].numeric_val.sval= (unsigned short)((UV)int_val);
+          else
+            imp_sth->fbind[idx].numeric_val.sval= (signed short)((IV)int_val);
+          buffer= (void*)&(imp_sth->fbind[idx].numeric_val.sval);
+          int_val= imp_sth->fbind[idx].numeric_val.sval;
+          int_type= "SHORT INT";
           break;
 
-        case MYSQL_TYPE_BLOB:
-          if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-            PerlIO_printf(DBIc_LOGPIO(imp_xxh),
-                          "   SCALAR type BLOB\n");
+        case MYSQL_TYPE_LONG:
+          buffer_length= sizeof(imp_sth->fbind[idx].numeric_val.lval);
+          if (int_val > INT32_MAX)
+            buffer_is_unsigned= 1;
+          if (buffer_is_unsigned)
+            imp_sth->fbind[idx].numeric_val.lval= (uint32_t)((UV)int_val);
+          else
+            imp_sth->fbind[idx].numeric_val.lval= (int32_t)((IV)int_val);
+          buffer= (void*)&(imp_sth->fbind[idx].numeric_val.lval);
+          int_val= imp_sth->fbind[idx].numeric_val.lval;
+          int_type= "LONG INT";
           break;
 
-        case MYSQL_TYPE_STRING:
-          if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-            PerlIO_printf(DBIc_LOGPIO(imp_xxh),
-                          "   SCALAR type STRING %"IVdf", buffertype=%d\n", sql_type, buffer_type);
+#if IVSIZE >= 8
+        case MYSQL_TYPE_LONGLONG:
+          buffer_length= sizeof(imp_sth->fbind[idx].numeric_val.llval);
+          if (int_val > LLONG_MAX)
+            buffer_is_unsigned= 1;
+          if (buffer_is_unsigned)
+            imp_sth->fbind[idx].numeric_val.llval= (UV)int_val;
+          else
+            imp_sth->fbind[idx].numeric_val.llval= (IV)int_val;
+          int_val= imp_sth->fbind[idx].numeric_val.llval;
+          int_type= "LONGLONG INT";
+          buffer= (void*)&(imp_sth->fbind[idx].numeric_val.llval);
           break;
+#endif
+        }
 
-        default:
-          croak("Bug in DBD::Mysql file dbdimp.c#dbd_bind_ph: do not know how to handle unknown buffer type.");
-      }
+        if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+        {
+          if (buffer_is_unsigned)
+            PerlIO_printf(DBIc_LOGPIO(imp_xxh),
+                          "   SCALAR sql_type %"IVdf" ->%"UVuf"<- IS AN UNSIGNED %s NUMBER\n",
+                          sql_type, (UV)int_val, int_type);
+          else
+            PerlIO_printf(DBIc_LOGPIO(imp_xxh),
+                          "   SCALAR sql_type %"IVdf" ->%"IVdf"<- IS A SIGNED %s NUMBER\n",
+                          sql_type, (IV)int_val, int_type);
+        }
+        break;
 
-      if (buffer_type == MYSQL_TYPE_STRING || buffer_type == MYSQL_TYPE_BLOB)
-      {
+#if IVSIZE < 8
+      case MYSQL_TYPE_LONGLONG:
+        {
+          char *buf;
+          my_ulonglong val;
+
+          buffer_length= sizeof(imp_sth->fbind[idx].numeric_val.llval);
+
+          if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+            PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tTRY TO BIND AN LONGLONG INT NUMBER FROM STRING\n");
+
+          buf= SvPV_nolen(imp_sth->params[idx].value);
+          val= strtoll(buf, NULL, 10);
+          if (val == LLONG_MAX)
+          {
+            val= strtoull(buf, NULL, 10);
+            buffer_is_unsigned= 1;
+          }
+
+          imp_sth->fbind[idx].numeric_val.llval= val;
+          buffer= (void*)&(imp_sth->fbind[idx].numeric_val.llval);
+
+          if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+          {
+            if (buffer_is_unsigned)
+              PerlIO_printf(DBIc_LOGPIO(imp_xxh),
+                            "   SCALAR sql_type %"IVdf" ->%llu<- IS AN UNSIGNED LONGLONG INT NUMBER\n",
+                            sql_type, imp_sth->fbind[idx].numeric_val.llval);
+            else
+              PerlIO_printf(DBIc_LOGPIO(imp_xxh),
+                            "   SCALAR sql_type %"IVdf" ->%lld<- IS A SIGNED LONGLONG INT NUMBER\n",
+                            sql_type, imp_sth->fbind[idx].numeric_val.llval);
+          }
+        }
+        break;
+#endif
+
+      case MYSQL_TYPE_FLOAT:
+        if (!SvNOK(imp_sth->params[idx].value) && DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+          PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tTRY TO BIND A FLOAT NUMBER\n");
+        buffer_length = sizeof(imp_sth->fbind[idx].numeric_val.fval);
+        imp_sth->fbind[idx].numeric_val.fval= SvNV(imp_sth->params[idx].value);
+        buffer=(char*)&(imp_sth->fbind[idx].numeric_val.fval);
+        if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+          PerlIO_printf(DBIc_LOGPIO(imp_xxh),
+                        "   SCALAR sql_type %"IVdf" ->%f<- IS A FLOAT NUMBER\n",
+                        sql_type, *(float *)buffer);
+        break;
+
+      case MYSQL_TYPE_DOUBLE:
+        if (!SvNOK(imp_sth->params[idx].value) && DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+          PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tTRY TO BIND A DOUBLE NUMBER\n");
+        buffer_length = sizeof(imp_sth->fbind[idx].numeric_val.dval);
+#if NVSIZE >= 8
+        imp_sth->fbind[idx].numeric_val.dval= SvNV(imp_sth->params[idx].value);
+#else
+        imp_sth->fbind[idx].numeric_val.dval= atof(SvPV_nolen(imp_sth->params[idx].value));
+#endif
+        buffer=(char*)&(imp_sth->fbind[idx].numeric_val.dval);
+        if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+          PerlIO_printf(DBIc_LOGPIO(imp_xxh),
+                        "   SCALAR sql_type %"IVdf" ->%f<- IS A DOUBLE NUMBER\n",
+                        sql_type, *(double *)buffer);
+        break;
+
+      /* TODO: datetime structures */
+#if 0
+      case MYSQL_TYPE_TIME:
+      case MYSQL_TYPE_DATE:
+      case MYSQL_TYPE_DATETIME:
+      case MYSQL_TYPE_TIMESTAMP:
+        break;
+#endif
+
+      case MYSQL_TYPE_BLOB:
         buffer= SvPV(imp_sth->params[idx].value, slen);
         buffer_length= slen;
         if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
           PerlIO_printf(DBIc_LOGPIO(imp_xxh),
-                        " SCALAR type %"IVdf" ->length %d<- IS A STRING or BLOB\n",
-                        sql_type, buffer_length);
+                        "   SCALAR sql_type %"IVdf" ->length %d<- IS A BLOB\n", sql_type, buffer_length);
+        break;
+
+      default:
+        buffer_type= MYSQL_TYPE_STRING;
+        buffer= SvPV(imp_sth->params[idx].value, slen);
+        buffer_length= slen;
+        if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+          PerlIO_printf(DBIc_LOGPIO(imp_xxh),
+                        "   SCALAR sql_type %"IVdf" ->%s<- IS A STRING\n", sql_type, buffer);
+        break;
       }
     }
     else
     {
-      /*case: buffer_is_null != 0*/
       buffer= NULL;
+      buffer_type= MYSQL_TYPE_NULL;
+      buffer_length= 0;
       if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
         PerlIO_printf(DBIc_LOGPIO(imp_xxh),
-                      "   SCALAR NULL VALUE: buffer type is: %d\n", buffer_type);
+                      "   SCALAR sql_type %"IVdf" IS A NULL VALUE", sql_type);
     }
 
     /* Type of column was changed. Force to rebind */

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1944,8 +1944,6 @@ MYSQL *mysql_dr_connect(
                         imp_dbh->disable_fallback_for_server_prepare);
 #endif
 
-        /* HELMUT */
-#if defined(sv_utf8_decode) && MYSQL_VERSION_ID >=SERVER_PREPARE_VERSION
         if ((svp = hv_fetch(hv, "mysql_enable_utf8mb4", 20, FALSE)) && *svp && SvTRUE(*svp)) {
           mysql_options(sock, MYSQL_SET_CHARSET_NAME, "utf8mb4");
         }
@@ -1961,7 +1959,6 @@ MYSQL *mysql_dr_connect(
                          "mysql_options: MYSQL_SET_CHARSET_NAME=%s\n",
                          (SvTRUE(*svp) ? "utf8" : "latin1"));
         }
-#endif
 
 #if defined(DBD_MYSQL_WITH_SSL) && !defined(DBD_MYSQL_EMBEDDED) && \
     (defined(CLIENT_SSL) || (MYSQL_VERSION_ID >= 40000))
@@ -2209,11 +2206,8 @@ int dbd_db_login(SV* dbh, imp_dbh_t* imp_dbh, char* dbname, char* user,
  /* Safer we flip this to TRUE perl side if we detect a mod_perl env. */
   imp_dbh->auto_reconnect = FALSE;
 
-  /* HELMUT */
-#if defined(sv_utf8_decode) && MYSQL_VERSION_ID >=SERVER_PREPARE_VERSION
   imp_dbh->enable_utf8 = FALSE;     /* initialize mysql_enable_utf8 */
   imp_dbh->enable_utf8mb4 = FALSE;  /* initialize mysql_enable_utf8mb4 */
-#endif
 
   if (!my_login(aTHX_ dbh, imp_dbh))
   {
@@ -2540,12 +2534,10 @@ dbd_db_STORE_attrib(
     imp_dbh->bind_type_guessing = bool_value;
   else if (kl == 31 && strEQ(key,"mysql_bind_comment_placeholders"))
     imp_dbh->bind_type_guessing = bool_value;
-#if defined(sv_utf8_decode) && MYSQL_VERSION_ID >=SERVER_PREPARE_VERSION
   else if (kl == 17 && strEQ(key, "mysql_enable_utf8"))
     imp_dbh->enable_utf8 = bool_value;
   else if (kl == 20 && strEQ(key, "mysql_enable_utf8mb4"))
     imp_dbh->enable_utf8mb4 = bool_value;
-#endif
 #if FABRIC_SUPPORT
   else if (kl == 22 && strEQ(key, "mysql_fabric_opt_group"))
     mysql_options(imp_dbh->pmysql, FABRIC_OPT_GROUP, (void *)SvPVbyte_nolen(valuesv));
@@ -2733,13 +2725,10 @@ SV* dbd_db_FETCH_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv)
       const char* msg = mysql_error(imp_dbh->pmysql);
       result= sv_2mortal(newSVpvn(msg, strlen(msg)));
     }
-    /* HELMUT */
-#if defined(sv_utf8_decode) && MYSQL_VERSION_ID >=SERVER_PREPARE_VERSION
     else if (kl == strlen("enable_utf8mb4") && strEQ(key, "enable_utf8mb4"))
         result = sv_2mortal(newSViv(imp_dbh->enable_utf8mb4));
     else if (kl == strlen("enable_utf8") && strEQ(key, "enable_utf8"))
         result = sv_2mortal(newSViv(imp_dbh->enable_utf8));
-#endif
     break;
 
   case 'd':
@@ -4353,10 +4342,6 @@ process:
 
           sv_setpvn(sv, fbh->data, len);
 
-	/* UTF8 */
-        /*HELMUT*/
-#if defined(sv_utf8_decode) && MYSQL_VERSION_ID >=SERVER_PREPARE_VERSION
-
 #if MYSQL_VERSION_ID >= FIELD_CHARSETNR_VERSION 
   /* SHOW COLLATION WHERE Id = 63; -- 63 == charset binary, collation binary */
         if ((imp_dbh->enable_utf8 || imp_dbh->enable_utf8mb4) && fbh->charsetnr != 63)
@@ -4364,8 +4349,6 @@ process:
 	if ((imp_dbh->enable_utf8 || imp_dbh->enable_utf8mb4) && !(fbh->flags & BINARY_FLAG))
 #endif
 	  sv_utf8_decode(sv);
-#endif
-	/* END OF UTF8 */
           break;
         }
       }
@@ -4506,15 +4489,9 @@ process:
 
         default:
           /* TEXT columns can be returned as MYSQL_TYPE_BLOB, so always check for charset */
-	/* UTF8 */
-        /*HELMUT*/
-#if defined(sv_utf8_decode) && MYSQL_VERSION_ID >=SERVER_PREPARE_VERSION
-
   /* see bottom of: http://www.mysql.org/doc/refman/5.0/en/c-api-datatypes.html */
         if ((imp_dbh->enable_utf8 || imp_dbh->enable_utf8mb4) && fields[i].charsetnr != 63)
 	  sv_utf8_decode(sv);
-#endif
-	/* END OF UTF8 */
           break;
         }
       }
@@ -5630,9 +5607,7 @@ SV* dbd_db_quote(SV *dbh, SV *str, SV *type)
 
     ptr= SvPV(str, len);
     result= newSV(len*2+3);
-#ifdef SvUTF8
     if (SvUTF8(str)) SvUTF8_on(result);
-#endif
     sptr= SvPVX(result);
 
     *sptr++ = '\'';

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2535,22 +2535,74 @@ dbd_db_STORE_attrib(
  *  Notes:   Do not forget to call sv_2mortal in the former case!
  *
  **************************************************************************/
-static SV*
-my_ulonglong2str(pTHX_ my_ulonglong val)
+
+#if IVSIZE < 8
+static char *
+my_ulonglong2str(my_ulonglong val, char *buf, STRLEN *len)
 {
-  char buf[64];
-  char *ptr = buf + sizeof(buf) - 1;
+  char *ptr = buf + *len - 1;
+
+  if (*len < 2)
+  {
+    *len = 0;
+    return NULL;
+  }
 
   if (val == 0)
-    return newSVpvn("0", 1);
+  {
+    buf[0] = '0';
+    buf[1] = '\0';
+    *len = 1;
+    return buf;
+  }
 
   *ptr = '\0';
   while (val > 0)
   {
+    if (ptr == buf)
+    {
+      *len = 0;
+      return NULL;
+    }
     *(--ptr) = ('0' + (val % 10));
     val = val / 10;
   }
-  return newSVpvn(ptr, (buf+ sizeof(buf) - 1) - ptr);
+
+  *len = (buf + *len - 1) - ptr;
+  return ptr;
+}
+
+static char*
+signed_my_ulonglong2str(my_ulonglong val, char *buf, STRLEN *len)
+{
+  char *ptr;
+
+  if (val <= LLONG_MAX)
+    return my_ulonglong2str(val, buf, len);
+
+  ptr = my_ulonglong2str(-val, buf, len);
+  if (!ptr || ptr == buf) {
+    *len = 0;
+    return NULL;
+  }
+
+  *(--ptr) = '-';
+  *len += 1;
+  return ptr;
+}
+#endif
+
+static SV*
+my_ulonglong2sv(pTHX_ my_ulonglong val)
+{
+#if IVSIZE >= 8
+  return newSVuv(val);
+#else
+  char buf[64];
+  STRLEN len = sizeof(buf);
+  char *ptr = my_ulonglong2str(val, buf, &len);
+  return newSVpvn(ptr, len);
+#endif
 }
 
 SV* dbd_db_FETCH_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv)
@@ -2604,7 +2656,7 @@ SV* dbd_db_FETCH_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv)
     }
     else if (kl == 13 && strEQ(key, "clientversion"))
     {
-      result= sv_2mortal(my_ulonglong2str(aTHX_ mysql_get_client_version()));
+      result= sv_2mortal(my_ulonglong2sv(aTHX_ mysql_get_client_version()));
     }
     break;
   case 'e':
@@ -2664,7 +2716,7 @@ SV* dbd_db_FETCH_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv)
     }
     else if (kl == 8  &&  strEQ(key, "insertid"))
       /* We cannot return an IV, because the insertid is a long. */
-      result= sv_2mortal(my_ulonglong2str(aTHX_ mysql_insert_id(imp_dbh->pmysql)));
+      result= sv_2mortal(my_ulonglong2sv(aTHX_ mysql_insert_id(imp_dbh->pmysql)));
     break;
   case 'n':
     if (kl == strlen("no_autocommit_cmd") &&
@@ -2684,7 +2736,7 @@ SV* dbd_db_FETCH_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv)
         sv_2mortal(newSVpvn(serverinfo, strlen(serverinfo))) : &PL_sv_undef;
     } 
     else if (kl == 13 && strEQ(key, "serverversion"))
-      result= sv_2mortal(my_ulonglong2str(aTHX_ mysql_get_server_version(imp_dbh->pmysql)));
+      result= sv_2mortal(my_ulonglong2sv(aTHX_ mysql_get_server_version(imp_dbh->pmysql)));
     else if (strEQ(key, "sock"))
       result= sv_2mortal(newSViv(PTR2IV(imp_dbh->pmysql)));
     else if (strEQ(key, "sockfd"))
@@ -4798,7 +4850,7 @@ dbd_st_FETCH_internal(
         if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
           PerlIO_printf(DBIc_LOGPIO(imp_xxh), "INSERT ID %llu\n", imp_sth->insertid);
 
-        return sv_2mortal(my_ulonglong2str(aTHX_ imp_sth->insertid));
+        return sv_2mortal(my_ulonglong2sv(aTHX_ imp_sth->insertid));
       }
       break;
     case 15:
@@ -5366,7 +5418,7 @@ SV *mysql_db_last_insert_id(SV *dbh, imp_dbh_t *imp_dbh,
   attr= attr;
 
   ASYNC_CHECK_RETURN(dbh, &PL_sv_undef);
-  return sv_2mortal(my_ulonglong2str(aTHX_ mysql_insert_id(imp_dbh->pmysql)));
+  return sv_2mortal(my_ulonglong2sv(aTHX_ mysql_insert_id(imp_dbh->pmysql)));
 }
 #endif
 

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -22,6 +22,7 @@
 #include <mysqld_error.h>  /* Comes MySQL */
 
 #include <errmsg.h> /* Comes with MySQL-devel */
+#include <stdint.h> /* For uint32_t */
 
 /* For now, we hardcode this, but in the future,
  * we can detect capabilities of the MySQL libraries
@@ -208,15 +209,23 @@ typedef struct imp_sth_ph_st {
 } imp_sth_ph_t;
 
 /*
+ *  Storage for numeric value in prepared statement
+ */
+typedef union numeric_val_u {
+    unsigned char tval;
+    unsigned short sval;
+    uint32_t lval;
+    my_ulonglong llval;
+    float fval;
+    double dval;
+} numeric_val_t;
+
+/*
  *  The bind_param method internally uses this structure for storing
  *  parameters.
  */
 typedef struct imp_sth_phb_st {
-    union
-    {
-      IV     lval;
-      double dval;
-    } numeric_val;
+    numeric_val_t   numeric_val;
     unsigned long   length;
     char            is_null;
 } imp_sth_phb_t;
@@ -224,9 +233,6 @@ typedef struct imp_sth_phb_st {
 /*
  *  The dbd_describe uses this structure for storing
  *  fields meta info.
- *  Added ddata, ldata, lldata for accomodate
- *  being able to use different data types
- *  12.02.20004 PMG
  */
 typedef struct imp_sth_fbh_st {
     unsigned long  length;
@@ -234,8 +240,7 @@ typedef struct imp_sth_fbh_st {
     bool           error;
     char           *data;
     int            charsetnr;
-    double         ddata;
-    IV             ldata;
+    numeric_val_t  numeric_val;
 #if MYSQL_VERSION_ID < FIELD_CHARSETNR_VERSION
     unsigned int   flags;
 #endif

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -202,7 +202,8 @@ struct imp_dbh_st {
  *  parameters.
  */
 typedef struct imp_sth_ph_st {
-    SV* value;
+    char* value;
+    STRLEN len;
     int type;
 } imp_sth_ph_t;
 
@@ -263,6 +264,8 @@ typedef struct imp_sth_fbind_st {
  */
 struct imp_sth_st {
     dbih_stc_t com;       /* MUST be first element in structure     */
+    char *statement;
+    STRLEN statement_len;
 
 #if (MYSQL_VERSION_ID >= SERVER_PREPARE_VERSION)
     MYSQL_STMT       *stmt;
@@ -340,7 +343,8 @@ SV	*dbd_db_fieldlist (MYSQL_RES* res);
 
 void    dbd_preparse (imp_sth_t *imp_sth, SV *statement);
 my_ulonglong mysql_st_internal_execute(SV *,
-                                       SV *,
+                                       char *,
+                                       STRLEN,
                                        SV *,
                                        int,
                                        imp_sth_ph_t *,

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -188,10 +188,8 @@ struct imp_dbh_st {
 #if MYSQL_ASYNC
     void* async_query_in_flight;
 #endif
-#if defined(sv_utf8_decode) && MYSQL_VERSION_ID >=SERVER_PREPARE_VERSION
     bool enable_utf8;
     bool enable_utf8mb4;
-#endif
     struct {
 	    unsigned int auto_reconnects_ok;
 	    unsigned int auto_reconnects_failed;

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -310,7 +310,7 @@ struct imp_sth_st {
 #define dbd_db_destroy		mysql_db_destroy
 #define dbd_db_STORE_attrib	mysql_db_STORE_attrib
 #define dbd_db_FETCH_attrib	mysql_db_FETCH_attrib
-#define dbd_st_prepare		mysql_st_prepare
+#define dbd_st_prepare_sv	mysql_st_prepare_sv
 #define dbd_st_execute		mysql_st_execute
 #define dbd_st_fetch		mysql_st_fetch
 #define dbd_st_more_results     mysql_st_next_results

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -205,6 +205,7 @@ typedef struct imp_sth_ph_st {
     char* value;
     STRLEN len;
     int type;
+    bool utf8;
 } imp_sth_ph_t;
 
 /*
@@ -388,3 +389,6 @@ int mysql_st_free_result_sets (SV * sth, imp_sth_t * imp_sth);
 int mysql_db_async_result(SV* h, MYSQL_RES** resp);
 int mysql_db_async_ready(SV* h);
 #endif
+
+void get_param(pTHX_ SV *param, int field, bool enable_utf8, bool is_binary, char **out_buf, STRLEN *out_len);
+void get_statement(pTHX_ SV *statement, bool enable_utf8, char **out_buf, STRLEN *out_len);

--- a/t/41int_min_max.t
+++ b/t/41int_min_max.t
@@ -77,7 +77,7 @@ sub test_int_type ($$$$) {
     ########################################
     # Try to insert under the limit value
     ########################################
-    ok($store->bind_param( 1, ($min-1)->bstr(), $perl_type ), "binding less than minimal $mysql_type, mode=$mode");
+    ok($store->bind_param( 1, ($min-1)->bstr(), $dbh->{mysql_server_prepare} ? DBI::SQL_VARCHAR : $perl_type ), "binding less than minimal $mysql_type, mode=$mode");
     if ($mode eq 'strict') {
         $@ = '';
         eval{$store->execute()};
@@ -98,7 +98,7 @@ sub test_int_type ($$$$) {
     ########################################
     # Try to insert over the limit value
     ########################################
-    ok($store->bind_param( 1, ($max+1)->bstr(), $perl_type ), "binding more than maximal $mysql_type, mode=$mode");
+    ok($store->bind_param( 1, ($max+1)->bstr(), $dbh->{mysql_server_prepare} ? DBI::SQL_VARCHAR : $perl_type ), "binding more than maximal $mysql_type, mode=$mode");
     if ($mode eq 'strict') {
         $@ = '';
         eval{$store->execute()};

--- a/t/55utf8.t
+++ b/t/55utf8.t
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+use warnings FATAL => 'all';
 
 use DBI;
 use Test::More;
@@ -22,7 +22,7 @@ if (!MinimumVersion($dbh, '5.0')) {
     plan skip_all =>
         "SKIP TEST: You must have MySQL version 5.0 and greater for this test to run";
 }
-plan tests => 16 * 2;
+plan tests => 92 * 2;
 
 for my $mysql_server_prepare (0, 1) {
 $dbh= DBI->connect("$test_dsn;mysql_server_prepare=$mysql_server_prepare;mysql_server_prepare_disable_fallback=1", $test_user, $test_password,
@@ -36,34 +36,61 @@ CREATE TABLE dbd_mysql_t55utf8 (
     bincol BLOB,
     shape GEOMETRY,
     binutf VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_bin,
-    profile TEXT CHARACTER SET utf8
+    profile TEXT CHARACTER SET utf8,
+    str2 VARCHAR(64) CHARACTER SET utf8,
+    ascii VARCHAR(64) CHARACTER SET latin1,
+    latin VARCHAR(64) CHARACTER SET latin1
 )
 EOT
 
 ok $dbh->do($create);
 
-my $utf8_str        = "\x{0100}dam";     # "Adam" with a macron.
-my $quoted_utf8_str = "'\x{0100}dam'";
+my $unicode_str        = "\N{U+0100}dam";   # Unicode "Adam" with a macron (internally stored as utf8)
+my $quoted_unicode_str = "'\N{U+0100}dam'";
 
-my $blob = "\x{c4}\x{80}dam"; # same as utf8_str but not utf8 encoded
-my $quoted_blob = "'\x{c4}\x{80}dam'";
+my $blob               = "\x{c4}\x{80}dam"; # UTF-8 representation of $unicode_str
+my $quoted_blob        = "'\x{c4}\x{80}dam'";
 
-cmp_ok $dbh->quote($utf8_str), 'eq', $quoted_utf8_str, 'testing quoting of utf 8 string';
+my $unicode_str2       = "\x{c1}dam";       # Unicode "Adam" with a acute (internally stored as latin1)
+my $ascii_str          = "?dam";            # ASCII representation of $unicode_str (and also $unicode_str2)
+my $latin1_str2        = "\x{c1}dam";       # Latin1 representation of $unicode_str2 (well, really same as $unicode_str2)
+my $blob2              = "\x{c3}\x{81}dam"; # UTF-8 representation of $unicode_str2
+
+cmp_ok $dbh->quote($unicode_str), 'eq', $quoted_unicode_str, 'testing quoting of utf 8 string';
 
 cmp_ok $dbh->quote($blob), 'eq', $quoted_blob, 'testing quoting of blob';
 
-#ok $dbh->{mysql_enable_utf8}, "mysql_enable_utf8 survive connect()";
 $dbh->{mysql_enable_utf8}=1;
+ok $dbh->do("SET NAMES utf8"), 'SET NAMES utf8';
+ok $dbh->do("SET SQL_MODE=''"), 'SET SQL_MODE=\'\'';
+
+# GeomFromText() is deprecated as of MySQL 5.7.6, use ST_GeomFromText() instead
+my $geomfromtext = $dbh->{mysql_serverversion} >= 50706 ? 'ST_GeomFromText' : 'GeomFromText';
 
 my $query = <<EOI;
-INSERT INTO dbd_mysql_t55utf8 (name, bincol, shape, binutf, profile)
-    VALUES (?, ?, GeomFromText('Point(132865 501937)'), ?, ?)
+INSERT INTO dbd_mysql_t55utf8 (name, bincol, shape, binutf, profile, str2, ascii, latin)
+    VALUES (?, ?, $geomfromtext('Point(132865 501937)'), ?, ?, ?, ?, ?)
 EOI
 
-ok $dbh->do($query, {}, $utf8_str, $blob, $utf8_str, $utf8_str), "INSERT query $query\n";
+# Do not use prepared statements because ST_GeomFromText() is not supported
+# With SET SQL_MODE='' is mysql_server_prepare_disable_fallback not working
+# And without SET SQL_MODE='' below 'Incorrect string value' are fatal errors, not warnings...
+my $sth = $dbh->prepare($query, { mysql_server_prepare => 0 }) or die "$DBI::errstr";
+ok $sth->bind_param(1, $unicode_str);
+ok $sth->bind_param(2, $blob, DBI::SQL_BINARY);
+ok $sth->bind_param(3, $unicode_str);
+ok $sth->bind_param(4, $unicode_str);
+ok $sth->bind_param(5, $unicode_str2);
+ok $sth->bind_param(6, $unicode_str);
+ok $sth->bind_param(7, $unicode_str2);
+ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok $sth->finish;
 
-$query = "SELECT name,bincol,asbinary(shape), binutf, profile FROM dbd_mysql_t55utf8 LIMIT 1";
-my $sth = $dbh->prepare($query) or die "$DBI::errstr";
+cmp_ok($dbh->{mysql_warning_count}, '==', 1, 'got warning for INSERT') or do { diag("SHOW WARNINGS:"); diag($_->[2]) foreach @{$dbh->selectall_arrayref("SHOW WARNINGS", { mysql_server_prepare => 0 })}; };
+cmp_ok($dbh->selectrow_arrayref("SHOW WARNINGS", { mysql_server_prepare => 0 })->[2], 'eq', 'Incorrect string value: \'\xC4\x80dam\' for column \'ascii\' at row 1');
+
+$query = "SELECT name,bincol,asbinary(shape), binutf, profile, str2, ascii, latin FROM dbd_mysql_t55utf8 LIMIT 1";
+$sth = $dbh->prepare($query) or die "$DBI::errstr";
 
 ok $sth->execute;
 
@@ -72,22 +99,102 @@ $ref = $sth->fetchrow_arrayref ;
 
 ok defined $ref;
 
-cmp_ok $ref->[0], 'eq', $utf8_str;
+cmp_ok $ref->[0], 'eq', $unicode_str;
+cmp_ok $ref->[1], 'eq', $blob;
+cmp_ok $ref->[3], 'eq', $unicode_str;
+cmp_ok $ref->[4], 'eq', $unicode_str;
+cmp_ok $ref->[5], 'eq', $unicode_str2;
+cmp_ok $ref->[6], 'eq', $ascii_str;
+cmp_ok $ref->[7], 'eq', $latin1_str2;
 
-cmp_ok $ref->[3], 'eq', $utf8_str;
-cmp_ok $ref->[4], 'eq', $utf8_str;
-
-SKIP: {
-        eval {use Encode;};
-          skip "Can't test is_utf8 tests 'use Encode;' not available", 2, if $@;
-          ok !Encode::is_utf8($ref->[1]), "blob was made utf8!.";
-
-          ok !Encode::is_utf8($ref->[2]), "shape was made utf8!.";
-      }
+ok !utf8::is_utf8($ref->[1]), 'returned blob is not internally stored as utf8';
+ok !utf8::is_utf8($ref->[2]), 'returned blob is not internally stored as utf8';
 
 cmp_ok $ref->[1], 'eq', $blob, "compare $ref->[1] eq $blob";
 
 ok $sth->finish;
+
+$dbh->{mysql_enable_utf8}=0;
+$ref = $dbh->selectrow_arrayref($query);
+ok defined $ref, 'got data';
+cmp_ok $ref->[0], 'eq', $blob, 'utf8 data are not utf8 decoded when mysql_enable_utf8 is disabled';
+cmp_ok $ref->[1], 'eq', $blob, 'utf8 data are not utf8 decoded when mysql_enable_utf8 is disabled';
+cmp_ok $ref->[3], 'eq', $blob, 'utf8 data are not utf8 decoded when mysql_enable_utf8 is disabled';
+cmp_ok $ref->[4], 'eq', $blob, 'utf8 data are not utf8 decoded when mysql_enable_utf8 is disabled';
+cmp_ok $ref->[5], 'eq', $blob2, 'utf8 data are not utf8 decoded when mysql_enable_utf8 is disabled';
+cmp_ok $ref->[6], 'eq', $ascii_str, 'latin1 data are not utf8 decoded when mysql_enable_utf8 is disabled';
+cmp_ok $ref->[7], 'eq', $blob2, 'latin1 data are not utf8 decoded when mysql_enable_utf8 is disabled';
+ok !utf8::is_utf8($ref->[0]), 'value does not have utf8 flag when mysql_enable_utf8 is disabled';
+ok !utf8::is_utf8($ref->[1]), 'value does not have utf8 flag when mysql_enable_utf8 is disabled';
+ok !utf8::is_utf8($ref->[2]), 'value does not have utf8 flag when mysql_enable_utf8 is disabled';
+ok !utf8::is_utf8($ref->[3]), 'value does not have utf8 flag when mysql_enable_utf8 is disabled';
+ok !utf8::is_utf8($ref->[4]), 'value does not have utf8 flag when mysql_enable_utf8 is disabled';
+ok !utf8::is_utf8($ref->[5]), 'value does not have utf8 flag when mysql_enable_utf8 is disabled';
+ok !utf8::is_utf8($ref->[6]), 'value does not have utf8 flag when mysql_enable_utf8 is disabled';
+ok !utf8::is_utf8($ref->[7]), 'value does not have utf8 flag when mysql_enable_utf8 is disabled';
+
+my @warnmsgs;
+$SIG{__WARN__} = sub { push @warnmsgs, $_[0]; };
+ok $dbh->selectrow_arrayref("SELECT 1 FROM dbd_mysql_t55utf8 WHERE name = ? AND str2 = $quoted_unicode_str", {}, $unicode_str);
+$SIG{__WARN__} = 'DEFAULT';
+is scalar @warnmsgs, 2, 'got warnings for wide character without mysql_enable_utf8';
+like $warnmsgs[0], qr/^Wide character in statement but mysql_enable_utf8 not set /, '';
+like $warnmsgs[1], qr/^Wide character in field 1 but mysql_enable_utf8 not set /, '';
+
+@warnmsgs = ();
+$SIG{__WARN__} = sub { push @warnmsgs, $_[0]; };
+ok $sth = $dbh->prepare("SELECT 1 FROM dbd_mysql_t55utf8 WHERE name = ? AND bincol = ? AND str2 = $quoted_unicode_str");
+like $warnmsgs[0], qr/^Wide character in statement but mysql_enable_utf8 not set /, '';
+ok $sth->execute($unicode_str, $unicode_str);
+like $warnmsgs[1], qr/^Wide character in field 1 but mysql_enable_utf8 not set /, '';
+like $warnmsgs[2], qr/^Wide character in field 2 but mysql_enable_utf8 not set /, '';
+ok $sth->execute($blob, $blob2);
+ok $sth->finish();
+$SIG{__WARN__} = 'DEFAULT';
+is scalar @warnmsgs, 3, 'got warnings for wide character';
+
+@warnmsgs = ();
+$SIG{__WARN__} = sub { push @warnmsgs, $_[0]; };
+ok $sth = $dbh->prepare("SELECT 1 FROM dbd_mysql_t55utf8 WHERE name = ? AND bincol = ? AND str2 = $quoted_unicode_str");
+like $warnmsgs[0], qr/^Wide character in statement but mysql_enable_utf8 not set /, '';
+ok $sth->bind_param(1, $unicode_str);
+like $warnmsgs[1], qr/^Wide character in field 1 but mysql_enable_utf8 not set /, '';
+ok $sth->bind_param(2, $unicode_str, DBI::SQL_BINARY);
+like $warnmsgs[2], qr/^Wide character in binary field 2 /, '';
+ok $sth->execute();
+ok $sth->finish();
+$SIG{__WARN__} = 'DEFAULT';
+is scalar @warnmsgs, 3, 'got warnings for wide character';
+
+$dbh->{mysql_enable_utf8}=1;
+ok $dbh->do("SET NAMES latin1"), 'SET NAMES latin1';
+$ref = $dbh->selectrow_arrayref($query);
+ok defined $ref, 'got data';
+cmp_ok $ref->[0], 'eq', $ascii_str, 'utf8 data are returned as latin1 when NAMES is latin1';
+cmp_ok $ref->[1], 'eq', $blob, 'blob is unchanged when NAMES is latin1';
+cmp_ok $ref->[3], 'eq', $ascii_str, 'utf8 data are returned as latin1 when NAMES is latin1';
+cmp_ok $ref->[4], 'eq', $ascii_str, 'utf8 data are returned as latin1 when NAMES is latin1';
+cmp_ok $ref->[5], 'eq', $latin1_str2, 'utf8 data are returned as latin1 when NAMES is latin1';
+cmp_ok $ref->[6], 'eq', $ascii_str, 'latin1 data are returned as latin1 when NAMES is latin1';
+cmp_ok $ref->[7], 'eq', $latin1_str2, 'latin1 data are returned as latin1 when NAMES is latin1';
+ok !utf8::is_utf8($ref->[0]), 'value does not have utf8 flag when NAMES is latin1';
+ok !utf8::is_utf8($ref->[1]), 'value does not have utf8 flag when NAMES is latin1';
+ok !utf8::is_utf8($ref->[2]), 'value does not have utf8 flag when NAMES is latin1';
+ok !utf8::is_utf8($ref->[3]), 'value does not have utf8 flag when NAMES is latin1';
+ok !utf8::is_utf8($ref->[4]), 'value does not have utf8 flag when NAMES is latin1';
+ok !utf8::is_utf8($ref->[5]), 'value does not have utf8 flag when NAMES is latin1';
+ok !utf8::is_utf8($ref->[6]), 'value does not have utf8 flag when NAMES is latin1';
+ok !utf8::is_utf8($ref->[7]), 'value does not have utf8 flag when NAMES is latin1';
+
+@warnmsgs = ();
+$SIG{__WARN__} = sub { push @warnmsgs, $_[0]; };
+ok $sth = $dbh->prepare("SELECT 1 FROM dbd_mysql_t55utf8 WHERE bincol = ?");
+ok $sth->bind_param(1, $unicode_str, DBI::SQL_BINARY);
+like $warnmsgs[0], qr/^Wide character in binary field 1 /, '';
+ok $sth->execute();
+ok $sth->finish();
+$SIG{__WARN__} = 'DEFAULT';
+is scalar @warnmsgs, 1, 'got warnings for UTF-8 encoded binary field';
 
 ok $dbh->do("DROP TABLE dbd_mysql_t55utf8");
 

--- a/t/55utf8mb4.t
+++ b/t/55utf8mb4.t
@@ -35,6 +35,18 @@ ok(my $ref = $sth->fetchrow_arrayref, 'fetch row');
 ok($sth->finish, 'close sth');
 cmp_ok $ref->[0], 'eq', "😈";
 cmp_ok $ref->[1], 'eq', "F09F9888";
+ok(!utf8::is_utf8($ref->[0]), "utf8 flag is not set without mysql_enable_utf8mb4");
+
+use utf8;
+$dbh->{mysql_enable_utf8mb4} = 1;
+$sth = $dbh->prepare($query) or die "$DBI::errstr";
+ok $sth->execute;
+ok($ref = $sth->fetchrow_arrayref, 'fetch row with mysql_enable_utf8mb4');
+ok($sth->finish, 'close sth');
+cmp_ok $ref->[0], 'eq', "😈", 'test U+1F608 with mysql_enable_utf8mb4 and utf8 pragma';
+cmp_ok $ref->[1], 'eq', "F09F9888";
+$dbh->{mysql_enable_utf8mb4} = 0;
+no utf8;
 
 $dbh->disconnect();
 done_testing;

--- a/t/90utf8_params.t
+++ b/t/90utf8_params.t
@@ -1,0 +1,85 @@
+#!perl -w
+# vim: ft=perl
+#
+#   This checks for UTF-8 parameter support.
+#
+
+use strict;
+use DBI;
+use DBI::Const::GetInfoType;
+use Carp qw(croak);
+use Test::More;
+use vars qw($table $test_dsn $test_user $test_password); 
+use vars qw($COL_NULLABLE $COL_KEY);
+use lib 't', '.';
+require 'lib.pl';
+
+my $nasty_bytes = chr(0xc3).chr(0xbf); # looks like character 0xff, if you accidentally utf8 decode
+utf8::downgrade($nasty_bytes);
+my $nasty_utf8 = $nasty_bytes;
+utf8::upgrade($nasty_utf8);
+
+is($nasty_bytes, $nasty_utf8, "Perl's internal form does not matter");
+
+foreach my $enable_utf8 (0, 1) {
+    my $enable_str = "mysql_enable_utf8=$enable_utf8";
+
+    my $dbh = DBI->connect($test_dsn, $test_user, $test_password, { mysql_enable_utf8 => $enable_utf8 }) or die DBI->errstr;
+    
+    if ($dbh->get_info($GetInfoType{SQL_DBMS_VER}) lt "5.0") {
+        plan skip_all => 
+            "SKIP TEST: You must have MySQL version 5.0 and greater for this test to run";
+    }
+
+
+    foreach my $charset ("latin1", "utf8") {
+        $dbh->do("DROP TABLE IF EXISTS utf8_test");
+        $dbh->do(qq{
+            CREATE TABLE utf8_test (
+                payload VARCHAR(20),
+                id int(10)
+            ) CHARACTER SET $charset
+        }) or die $dbh->errstr;
+
+
+        $dbh->do("INSERT INTO utf8_test (id, payload) VALUES (1, ?), (2, ?)", {}, $nasty_bytes, $nasty_utf8);
+
+
+        $dbh->do("INSERT INTO utf8_test (id, payload) VALUES (3, '$nasty_bytes')");
+        $dbh->do("INSERT INTO utf8_test (id, payload) VALUES (4, '$nasty_utf8')");
+
+        my $sth = $dbh->prepare("INSERT INTO utf8_test (id, payload) VALUES (?, ?)");
+        $sth->execute(5, $nasty_bytes);
+        $sth->execute(6, $nasty_utf8);
+
+        $sth = $dbh->prepare("INSERT INTO utf8_test (id, payload) VALUES (?, ?)");
+        $sth->bind_param(1, 7);
+        $sth->bind_param(2, $nasty_bytes);
+        $sth->execute;
+
+        $sth = $dbh->prepare("INSERT INTO utf8_test (id, payload) VALUES (?, ?)");
+        $sth->bind_param(1, 8);
+        $sth->bind_param(2, $nasty_utf8);
+        $sth->execute;
+
+        my @trials = (
+            'do with supplied params',
+            'do with interpolated string',
+            'prepare then execute',
+            'prepare, bind, execute'
+        );
+
+        for (my $i = 0; $i<@trials; $i++) {
+            my $bytes = $i*2+1;
+            my $utf8s = $i*2+2;
+
+            (my $out) = $dbh->selectrow_array("SELECT payload FROM utf8_test WHERE id = $bytes");
+            is($out, chr(0xc3).chr(0xbf), "$trials[$i] / utf8 unset / $charset / $enable_str");
+
+            ($out) = $dbh->selectrow_array("SELECT payload FROM utf8_test WHERE id = $utf8s");
+            is($out, chr(0xc3).chr(0xbf), "$trials[$i] / utf8 set / $charset / $enable_str");
+        }
+    }
+}
+
+done_testing();


### PR DESCRIPTION
**WARNING:** This pull request changes behavior of mysql_enable_utf8 and mysql_enable_utf8mb4 attributes. New behavior is documented in POD section. Changes should be properly reviewed and tested as in some situations it can be backward incompatible change...

Probably people affected by UTF-8 bugs in DBD::mysql should test and verify that it really fix reported problems. Maybe we should discuss more about this pull request.

Reported bugs:
https://rt.cpan.org/Public/Bug/Display.html?id=25590
https://rt.cpan.org/Public/Bug/Display.html?id=53130
https://rt.cpan.org/Public/Bug/Display.html?id=60987
https://rt.cpan.org/Public/Bug/Display.html?id=87428

---

Important changes:
- Fix support for prepared statement numeric storage, DBI SQL bind types
- Make consistency between DBI, mysql and perl types
- Do not UTF-8 encode input binded params which are of DBI SQL BINARY types
- Do not UTF-8 decode output fields which are not send in utf8 (resp. utf8mb4) charset from mysql server
- Use SvPVutf8() for retrieving UTF-8 encoded char \* because SvPV() can return char \* in Latin1
- Remove #ifdef checks for sv_utf8_decode and SvUTF8 as they are not needed anymore

---

Part of this pull request is @davel (Dave Lambley) test for UTF-8 params from https://github.com/davel/DBD-mysql/commit/8695068684919d9751550a88aaf22df961eb5359 references by https://rt.cpan.org/Public/Bug/Display.html?id=60987. I slightly modified it, but it is still great test case for scenario with different table charset, different session charset and state of mysql_enable_utf8.

---

Prepared statements now uses only necessary long buffers for integer types
(not always 64bit anymore). DBI SQL types SQL_BOOLEAN and SQL_TINYINT now
handles 8bit integers, SQL_SMALLINT 16bit integers, SQL_INTEGER 32bit
integers and SQL_BIGINT 64bit integers. SQL_FLOAT native floats and
SQL_DOUBLE or SQL_REAL native doubles.

Now when prepared statements are enabled and explicit storage of numeric
values (different integer size and floating point size) via DBI SQL is
used, conversion to storage type is done by DBD::mysql driver and not by
mysql server. It means that any overflow/underflow is not detected by mysql
server and application needs to handle it.
    
SQL_BOOLEAN is treated as numeric type and SQL_DECIMAL is handed by mysql
as string type (due to decimal precision). SQL_BIT, SQL_BLOB, SQL_BINARY,
SQL_VARBINARY and SQL_LONGVARBINARY are treated as perl binary types.

And MYSQL_TYPE_BIT, MYSQL_TYPE_MEDIUM_BLOB and MYSQL_TYPE_LONG_BLOB are
treated as binary perl types. MYSQL_TYPE_LONGLONG as numeric perl type on
platforms with 64 bit perl's integers and string perl type on others.
MYSQL_TYPE_NULL is now perl's undef.

---

For each fetched field mysql server tells us also charset id. Before this
commit when mysql_enable_utf8 was enabled DBD::mysql UTF-8 decoded all
fields with charset id different of 63 (means binary).

Now DBD::mysql UTF-8 decode only those fields which have charset set to
utf8 or utf8mb4. By default mysql server sends data in encoding specified
by SET NAMES command, which is by default Latin1. So received Latin1 data
are not UTF-8 decoded anymore.

---

Before this commit perl scalars (statements or bind parameters) without
UTF8 status flag were not encoded to UTF-8 even if mysql_enable_utf8 was
enabled. It caused that perl scalars with internal Latin1 encoding were
send to mysql server as Latin1 even if mysql_enable_utf8 was enabled.

Now all statements and bind parameters which are not of DBI binary type
(SQL_BIT, SQL_BLOB, SQL_BINARY, SQL_VARBINARY and SQL_LONGVARBINARY) are
automatically encoded to UTF-8 when mysql_enable_utf8 is enabled.

If mysql_enable_utf8 is not enabled and statement or bind parameter
contains wide Unicode character then DBD::mysql shows warning. If binary
parameter contains wide Unicode character then DBD::mysql shows warning
too. Similar like function print without :utf8 perlio layer.