### PR TITLE
Commit 8e7ce0b "MYSQL_OPT_NET_BUFFER_LENGTH not defined in mariadb-10…

### DIFF
--- a/mysql.xs
+++ b/mysql.xs
@@ -882,7 +882,8 @@ dbd_mysql_get_info(dbh, sql_info_type)
     IV type = 0;
     SV* retsv=NULL;
     bool using_322=0;
-#ifdef MYSQL_OPT_NET_BUFFER_LENGTH
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 50709
+/* MariaDB 10 is not MySQL source level compatible so this only applies to MySQL*/
     IV buffer_len;
 #endif 
 
@@ -913,7 +914,9 @@ dbd_mysql_get_info(dbh, sql_info_type)
 	    retsv = newSVpv("`", 1);
 	    break;
 	case SQL_MAXIMUM_STATEMENT_LENGTH:
-#ifdef MYSQL_OPT_NET_BUFFER_LENGTH
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 50709
+        /* MariaDB 10 is not MySQL source level compatible so this
+           only applies to MySQL*/
 	    /* mysql_get_option() was added in mysql 5.7.3 */
 	    /* MYSQL_OPT_NET_BUFFER_LENGTH was added in mysql 5.7.9 */
 	    mysql_get_option(NULL, MYSQL_OPT_NET_BUFFER_LENGTH, &buffer_len);


### PR DESCRIPTION
Commit 8e7ce0b breaks compatability with MySQL. MYSQL_OPT_NET_BUFFER_LENGTH is not a macro but an enum, so we need to need to distinguish between MySQL and MariaDB.