### PR TITLE
Add new attribute mysql_server_prepare_disable_fallback which disable any fallback from prepared statement to normal non-prepared

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1869,6 +1869,13 @@ MYSQL *mysql_dr_connect(
           PerlIO_printf(DBIc_LOGPIO(imp_xxh),
                         "imp_dbh->use_server_side_prepare: %d\n",
                         imp_dbh->use_server_side_prepare);
+
+        if ((svp = hv_fetch(hv, "mysql_server_prepare_disable_fallback", 37, FALSE)) && *svp)
+          imp_dbh->disable_fallback_for_server_prepare = SvTRUE(*svp);
+        if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
+          PerlIO_printf(DBIc_LOGPIO(imp_xxh),
+                        "imp_dbh->disable_fallback_for_server_prepare: %d\n",
+                        imp_dbh->disable_fallback_for_server_prepare);
 #endif
 
         /* HELMUT */
@@ -2455,6 +2462,8 @@ dbd_db_STORE_attrib(
     imp_dbh->auto_reconnect = bool_value;
   else if (kl == 20 && strEQ(key, "mysql_server_prepare"))
     imp_dbh->use_server_side_prepare = bool_value;
+  else if (kl == 37 && strEQ(key, "mysql_server_prepare_disable_fallback"))
+    imp_dbh->disable_fallback_for_server_prepare = bool_value;
   else if (kl == 23 && strEQ(key,"mysql_no_autocommit_cmd"))
     imp_dbh->no_autocommit_cmd = bool_value;
   else if (kl == 24 && strEQ(key,"mysql_bind_type_guessing"))
@@ -2690,6 +2699,8 @@ SV* dbd_db_FETCH_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv)
     }
     else if (kl == 14 && strEQ(key,"server_prepare"))
         result= sv_2mortal(newSViv((IV) imp_dbh->use_server_side_prepare));
+    else if (kl == 31 && strEQ(key, "server_prepare_disable_fallback"))
+        result= sv_2mortal(newSViv((IV) imp_dbh->disable_fallback_for_server_prepare));
     break;
 
   case 't':
@@ -2765,17 +2776,28 @@ dbd_st_prepare(
 #if MYSQL_VERSION_ID >= SERVER_PREPARE_VERSION
  /* Set default value of 'mysql_server_prepare' attribute for sth from dbh */
   imp_sth->use_server_side_prepare= imp_dbh->use_server_side_prepare;
+  imp_sth->disable_fallback_for_server_prepare= imp_dbh->disable_fallback_for_server_prepare;
   if (attribs)
   {
     svp= DBD_ATTRIB_GET_SVP(attribs, "mysql_server_prepare", 20);
     imp_sth->use_server_side_prepare = (svp) ?
       SvTRUE(*svp) : imp_dbh->use_server_side_prepare;
 
+    svp= DBD_ATTRIB_GET_SVP(attribs, "mysql_server_prepare_disable_fallback", 37);
+    imp_sth->disable_fallback_for_server_prepare = (svp) ?
+      SvTRUE(*svp) : imp_dbh->disable_fallback_for_server_prepare;
+
     svp = DBD_ATTRIB_GET_SVP(attribs, "async", 5);
 
     if(svp && SvTRUE(*svp)) {
 #if MYSQL_ASYNC
         imp_sth->is_async = TRUE;
+        if (imp_sth->disable_fallback_for_server_prepare)
+        {
+          do_error(sth, ER_UNSUPPORTED_PS,
+                   "Async option not supported with server side prepare", "HY000");
+          return 0;
+        }
         imp_sth->use_server_side_prepare = FALSE;
 #else
         do_error(sth, 2000,
@@ -2842,6 +2864,15 @@ dbd_st_prepare(
           if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
             PerlIO_printf(DBIc_LOGPIO(imp_xxh),
                     "\t\tLIMIT and ? found, set to use_server_side_prepare=0\n");
+          if (imp_sth->disable_fallback_for_server_prepare)
+          {
+            do_error(sth, ER_UNSUPPORTED_PS,
+                     "\"LIMIT ?\" not supported with server side prepare",
+                     "HY000");
+            mysql_stmt_close(imp_sth->stmt);
+            imp_sth->stmt= NULL;
+            return FALSE;
+          }
           /* ... then we do not want to try server side prepare (use emulation) */
           imp_sth->use_server_side_prepare= 0;
           break;
@@ -2873,6 +2904,15 @@ dbd_st_prepare(
       {
         if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
           PerlIO_printf(DBIc_LOGPIO(imp_xxh), "Disable PS mode for CALL()\n");
+          if (imp_sth->disable_fallback_for_server_prepare)
+          {
+            do_error(sth, ER_UNSUPPORTED_PS,
+                     "\"CALL()\" not supported with server side prepare",
+                     "HY000");
+            mysql_stmt_close(imp_sth->stmt);
+            imp_sth->stmt= NULL;
+            return FALSE;
+          }
         imp_sth->use_server_side_prepare= 0;
         break;
       }
@@ -2922,7 +2962,7 @@ dbd_st_prepare(
 
       /* For commands that are not supported by server side prepared statement
          mechanism lets try to pass them through regular API */
-      if (mysql_stmt_errno(imp_sth->stmt) == ER_UNSUPPORTED_PS)
+      if (!imp_sth->disable_fallback_for_server_prepare && mysql_stmt_errno(imp_sth->stmt) == ER_UNSUPPORTED_PS)
       {
         if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
           PerlIO_printf(DBIc_LOGPIO(imp_xxh),
@@ -3594,6 +3634,7 @@ int dbd_st_execute(SV* sth, imp_sth_t* imp_sth)
 #endif
 #if MYSQL_VERSION_ID >= SERVER_PREPARE_VERSION
   int use_server_side_prepare = imp_sth->use_server_side_prepare;
+  int disable_fallback_for_server_prepare = imp_sth->disable_fallback_for_server_prepare;
 #endif
 
   ASYNC_CHECK_RETURN(sth, -2);
@@ -3627,6 +3668,13 @@ int dbd_st_execute(SV* sth, imp_sth_t* imp_sth)
   {
     if (imp_sth->use_mysql_use_result)
     {
+      if (disable_fallback_for_server_prepare)
+      {
+        do_error(sth, ER_UNSUPPORTED_PS,
+                 "\"mysql_use_result\" not supported with server side prepare",
+                 "HY000");
+        return 0;
+      }
       use_server_side_prepare = 0;
     }
 
@@ -3643,7 +3691,7 @@ int dbd_st_execute(SV* sth, imp_sth_t* imp_sth)
       if (imp_sth->row_num == (my_ulonglong)-2) /* -2 means error */
       {
         SV *err = DBIc_ERR(imp_xxh);
-        if (SvIV(err) == ER_UNSUPPORTED_PS)
+        if (!disable_fallback_for_server_prepare && SvIV(err) == ER_UNSUPPORTED_PS)
         {
           use_server_side_prepare = 0;
         }
@@ -4775,6 +4823,14 @@ dbd_st_FETCH_internal(
     case 23:
       if (strEQ(key, "mysql_is_auto_increment"))
         retsv = ST_FETCH_AV(AV_ATTRIB_IS_AUTO_INCREMENT);
+      break;
+    case 37:
+      if (strEQ(key, "mysql_server_prepare_disable_fallback"))
+#if MYSQL_VERSION_ID >= SERVER_PREPARE_VERSION
+        retsv= sv_2mortal(newSViv((IV) imp_sth->disable_fallback_for_server_prepare));
+#else
+        retsv= boolSV(0);
+#endif
       break;
     }
     break;

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -183,6 +183,7 @@ struct imp_dbh_st {
                                * mysql_store_result
                                */
     bool use_server_side_prepare;
+    bool disable_fallback_for_server_prepare;
 #if MYSQL_ASYNC
     void* async_query_in_flight;
 #endif
@@ -268,6 +269,7 @@ struct imp_sth_st {
     imp_sth_fbh_t    *fbh;
     int              has_been_bound;
     int use_server_side_prepare;  /* server side prepare statements? */
+    int disable_fallback_for_server_prepare;
 #endif
 
     MYSQL_RES* result;       /* result                                 */

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1201,7 +1201,9 @@ Support for multiple statements separated by a semicolon
 (;) may be enabled by using this option. Enabling this option may cause
 problems if server-side prepared statements are also enabled.
 
-=item Prepared statement support (server side prepare)
+=item mysql_server_prepare
+
+This option is used to enable server side prepared statements.
 
 To use server side prepared statements, all you need to do is set the variable
 mysql_server_prepare in the connect:
@@ -1213,6 +1215,15 @@ mysql_server_prepare in the connect:
     { RaiseError => 1, AutoCommit => 1 }
   );
 
+or:
+
+  $dbh = DBI->connect(
+    "DBI:mysql:database=test;host=localhost",
+    "",
+    "",
+    { RaiseError => 1, AutoCommit => 1, mysql_server_prepare => 1 }
+  );
+
 There are many benefits to using server side prepare statements, mostly if you are
 performing many inserts because of that fact that a single statement is prepared
 to accept multiple insert values.
@@ -1222,6 +1233,17 @@ need to export the env variable MYSQL_SERVER_PREPARE:
 
   export MYSQL_SERVER_PREPARE=1
 
+Please note that mysql server cannot prepare or execute some prepared statements.
+In this case DBD::mysql fallbacks to normal non-prepared statement and tries again.
+
+=item mysql_server_prepare_disable_fallback
+
+This option disable fallback to normal non-prepared statement when mysql server
+does not support execution of current statement as prepared.
+
+Useful when you want to be sure that statement is going to be executed as
+server side prepared. Error message and code in case of failure is propagated
+back to DBI.
 
 =item mysql_embedded_options
 

--- a/mysql.xs
+++ b/mysql.xs
@@ -522,6 +522,15 @@ do(dbh, statement, attr=Nullsv, ...)
         fprintf(stderr, "\n failed while closing the statement");
         fprintf(stderr, "\n %s", mysql_stmt_error(stmt));
       }
+
+      if (retval == -2) /* -2 means error */
+      {
+        SV *err = DBIc_ERR(imp_dbh);
+        if (SvIV(err) == ER_UNSUPPORTED_PS)
+        {
+          use_server_side_prepare = 0;
+        }
+      }
     }
   }
 

--- a/mysql.xs
+++ b/mysql.xs
@@ -272,6 +272,7 @@ do(dbh, statement, attr=Nullsv, ...)
   int             buffer_type= 0;
   int             param_type= SQL_VARCHAR;
   int             use_server_side_prepare= 0;
+  int             disable_fallback_for_server_prepare= 0;
   MYSQL_STMT      *stmt= NULL;
   MYSQL_BIND      *bind= NULL;
   imp_sth_phb_t   *fbind= NULL;
@@ -305,6 +306,10 @@ do(dbh, statement, attr=Nullsv, ...)
     use_server_side_prepare = (svp) ?
       SvTRUE(*svp) : imp_dbh->use_server_side_prepare;
 
+    svp = DBD_ATTRIB_GET_SVP(attr, "mysql_server_prepare_disable_fallback", 37);
+    disable_fallback_for_server_prepare = (svp) ?
+      SvTRUE(*svp) : imp_dbh->disable_fallback_for_server_prepare;
+
     svp   = DBD_ATTRIB_GET_SVP(attr, "async", 5);
     async = (svp) ? *svp : &PL_sv_no;
   }
@@ -317,6 +322,12 @@ do(dbh, statement, attr=Nullsv, ...)
 
   if(SvTRUE(async)) {
 #if MYSQL_ASYNC
+    if (disable_fallback_for_server_prepare)
+    {
+      do_error(dbh, ER_UNSUPPORTED_PS,
+               "Async option not supported with server side prepare", "HY000");
+      XSRETURN_UNDEF;
+    }
     use_server_side_prepare = FALSE; /* for now */
     imp_dbh->async_query_in_flight = imp_dbh;
 #else
@@ -340,7 +351,7 @@ do(dbh, statement, attr=Nullsv, ...)
         For commands that are not supported by server side prepared
         statement mechanism lets try to pass them through regular API
       */
-      if (mysql_stmt_errno(stmt) == ER_UNSUPPORTED_PS)
+      if (!disable_fallback_for_server_prepare && mysql_stmt_errno(stmt) == ER_UNSUPPORTED_PS)
       {
         use_server_side_prepare= 0;
       }
@@ -526,7 +537,7 @@ do(dbh, statement, attr=Nullsv, ...)
       if (retval == -2) /* -2 means error */
       {
         SV *err = DBIc_ERR(imp_dbh);
-        if (SvIV(err) == ER_UNSUPPORTED_PS)
+        if (!disable_fallback_for_server_prepare && SvIV(err) == ER_UNSUPPORTED_PS)
         {
           use_server_side_prepare = 0;
         }

--- a/t/15reconnect.t
+++ b/t/15reconnect.t
@@ -19,7 +19,7 @@ if ($@) {
 plan tests => 8 * 2;
 
 for my $mysql_server_prepare (0, 1) {
-$dbh= DBI->connect($test_dsn . ';mysql_server_prepare=' . $mysql_server_prepare, $test_user, $test_password,
+$dbh= DBI->connect("$test_dsn;mysql_server_prepare=$mysql_server_prepare;mysql_server_prepare_disable_fallback=1", $test_user, $test_password,
                       { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
 ok(defined $dbh, "Connected to database");

--- a/t/40server_prepare.t
+++ b/t/40server_prepare.t
@@ -18,7 +18,7 @@ eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
 if ($@) {
     plan skip_all => "no database connection";
 }
-plan tests => 27;
+plan tests => 31;
 
 ok(defined $dbh, "connecting");
 
@@ -77,6 +77,21 @@ ok($sth3 = $dbh->prepare(q{INSERT INTO t3 VALUES (?,?)}));
 ok($sth3->execute(1, 2), "insert t3");
 
 is_deeply($dbh->selectall_arrayref('SELECT id, mydata FROM t3'), [[1, 2]]);
+
+my $dbname = $dbh->selectrow_arrayref("SELECT DATABASE()")->[0];
+
+$dbh->{mysql_server_prepare_disable_fallback} = 1;
+my $error_handler_called = 0;
+$dbh->{HandleError} = sub { $error_handler_called = 1; die $_[0]; };
+eval { $dbh->prepare("USE $dbname") };
+$dbh->{HandleError} = undef;
+ok($error_handler_called, 'USE is not supported with mysql_server_prepare_disable_fallback=1');
+
+$dbh->{mysql_server_prepare_disable_fallback} = 0;
+my $sth4;
+ok($sth4 = $dbh->prepare("USE $dbname"), 'USE is supported with mysql_server_prepare_disable_fallback=0');
+ok($sth4->execute());
+ok($sth4->finish());
 
 ok ($dbh->do(qq{DROP TABLE t3}), "cleaning up");
 

--- a/t/40server_prepare.t
+++ b/t/40server_prepare.t
@@ -9,7 +9,7 @@ use vars qw($test_dsn $test_user $test_password);
 
 $|= 1;
 
-$test_dsn.= ";mysql_server_prepare=1";
+$test_dsn.= ";mysql_server_prepare=1;mysql_server_prepare_disable_fallback=1";
 
 my $dbh;
 eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,

--- a/t/40server_prepare_crash.t
+++ b/t/40server_prepare_crash.t
@@ -7,7 +7,7 @@ use DBI;
 use vars qw($test_dsn $test_user $test_password);
 require "t/lib.pl";
 
-my $dbh = eval { DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 1, AutoCommit => 0, mysql_server_prepare => 1 }) };
+my $dbh = eval { DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 1, AutoCommit => 0, mysql_server_prepare => 1, mysql_server_prepare_disable_fallback => 1 }) };
 plan skip_all => "no database connection" if $@ or not $dbh;
 
 plan tests => 13;

--- a/t/40server_prepare_error.t
+++ b/t/40server_prepare_error.t
@@ -8,7 +8,7 @@ require 'lib.pl';
 
 use vars qw($test_dsn $test_user $test_password);
 
-$test_dsn.= ";mysql_server_prepare=1";
+$test_dsn.= ";mysql_server_prepare=1;mysql_server_prepare_disable_fallback=1";
 my $dbh;
 eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
   { RaiseError => 1, AutoCommit => 1})};

--- a/t/50chopblanks.t
+++ b/t/50chopblanks.t
@@ -17,7 +17,7 @@ if ($@) {
 plan tests => 36 * 2;
 
 for my $mysql_server_prepare (0, 1) {
-eval {$dbh= DBI->connect($test_dsn . ';mysql_server_prepare=' . $mysql_server_prepare, $test_user, $test_password,
+eval {$dbh= DBI->connect("$test_dsn;mysql_server_prepare=$mysql_server_prepare;mysql_server_prepare_disable_fallback=1", $test_user, $test_password,
                       { RaiseError => 1, PrintError => 1, AutoCommit => 1 });};
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t50chopblanks"), "drop table if exists dbd_mysql_t50chopblanks";

--- a/t/55utf8.t
+++ b/t/55utf8.t
@@ -25,7 +25,7 @@ if (!MinimumVersion($dbh, '5.0')) {
 plan tests => 16 * 2;
 
 for my $mysql_server_prepare (0, 1) {
-$dbh= DBI->connect($test_dsn . ';mysql_server_prepare=' . $mysql_server_prepare, $test_user, $test_password,
+$dbh= DBI->connect("$test_dsn;mysql_server_prepare=$mysql_server_prepare;mysql_server_prepare_disable_fallback=1", $test_user, $test_password,
                       { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t55utf8");

--- a/t/60leaks.t
+++ b/t/60leaks.t
@@ -52,7 +52,7 @@ for my $mysql_server_prepare (0, 1) {
 note "Testing memory leaks with mysql_server_prepare=$mysql_server_prepare\n";
 
 $dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                   { RaiseError => 1, PrintError => 1, AutoCommit => 0, mysql_server_prepare => $mysql_server_prepare });
+                   { RaiseError => 1, PrintError => 1, AutoCommit => 0, mysql_server_prepare => $mysql_server_prepare, mysql_server_prepare_disable_fallback => 1 });
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t60leaks");
 

--- a/t/99_bug_server_prepare_blob_null.t
+++ b/t/99_bug_server_prepare_blob_null.t
@@ -9,7 +9,7 @@ use lib 't', '.';
 require 'lib.pl';
 
 my $dbh;
-$test_dsn .= ';mysql_server_prepare=1';
+$test_dsn .= ';mysql_server_prepare=1;mysql_server_prepare_disable_fallback=1';
 eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
 if ($@) {

--- a/t/rt88006-bit-prepare.t
+++ b/t/rt88006-bit-prepare.t
@@ -13,7 +13,7 @@ my $dbh;
 my $sth;
 
 my $dsn = $test_dsn;
-$dsn .= ';mysql_server_prepare=1;' if $scenario eq 'prepare';
+$dsn .= ';mysql_server_prepare=1;mysql_server_prepare_disable_fallback=1' if $scenario eq 'prepare';
 eval {$dbh = DBI->connect($dsn, $test_user, $test_password,
   { RaiseError => 1, AutoCommit => 1})};
 


### PR DESCRIPTION
In some cases it is better to throw error that mysql server cannot prepare
or execute some statement as server-prepared instead fallbacking to normal
non-prepared one (and without any control from user application).

Now applications can set mysql_server_prepare_disable_fallback to 1 disable
this automatic fallback. Default value is 0 (= fallbacks are enabled).