### PR TITLE
add fallback option to treat BIGINTs as strings

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -53,7 +53,8 @@ Getopt::Long::GetOptions(
     "embedded=s",
     "mysql_config=s",
     "force-embedded",
-    "with-mysql=s"
+    "with-mysql=s",
+    "bigintasastring"
     ) || die Usage();
 
 my $source = {};
@@ -98,7 +99,7 @@ MSG
 
 for my $key (qw/testdb testhost testuser testpassword testsocket testport
                     cflags embedded libs nocatchstderr nossl nofoundrows
-                    ps-protocol bind-type-guessing force-embedded/)
+                    ps-protocol bind-type-guessing force-embedded bigintasastring/)
 {
   Configure($opt, $source, $key);
 }
@@ -240,6 +241,7 @@ if ($^O eq 'VMS') {
 $cflags .= " -DDBD_MYSQL_WITH_SSL" if !$opt->{'nossl'};
 $cflags .= " -DDBD_MYSQL_INSERT_ID_IS_GOOD" if $DBI::VERSION > 1.42;
 $cflags .= " -DDBD_NO_CLIENT_FOUND_ROWS" if $opt->{'nofoundrows'};
+$cflags .= " -DDBD_BIGINT_AS_A_STRING" if $opt->{'bigintasastring'};
 $cflags .= " -g ";
 my %o = ( 'NAME' => 'DBD::mysql',
 	  'INC' => $cflags,
@@ -627,7 +629,7 @@ perl Makefile.PL --testuser=username
       $opt->{$param} = $user;
 	  $source->{$param} = 'guessed';
     }
-    elsif ($param eq "nocatchstderr" || $param eq "nofoundrows") {
+    elsif ($param eq "nocatchstderr" || $param eq "nofoundrows" || $param eq 'bigintasastring') {
       $source->{$param} = "default";
       $opt->{$param} = 0;
     }

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -359,7 +359,6 @@ static enum enum_field_types mysql_to_perl_type(enum enum_field_types type)
   case MYSQL_TYPE_INT24:
   case MYSQL_TYPE_YEAR:
 #if IVSIZE >= 8
-  case MYSQL_TYPE_LONGLONG:
     enum_type= MYSQL_TYPE_LONGLONG;
 #else
     enum_type= MYSQL_TYPE_LONG;
@@ -379,8 +378,10 @@ static enum enum_field_types mysql_to_perl_type(enum enum_field_types type)
     enum_type= MYSQL_TYPE_DECIMAL;
     break;
 
-#if IVSIZE < 8
   case MYSQL_TYPE_LONGLONG:
+#if IVSIZE >= 8 && !DBD_BIGINT_AS_A_STRING
+    enum_type= MYSQL_TYPE_LONGLONG;
+    break;
 #endif
   case MYSQL_TYPE_DATE:
   case MYSQL_TYPE_TIME:
@@ -4969,12 +4970,17 @@ int dbd_bind_ph(SV *sth, imp_sth_t *imp_sth, SV *param, SV *value,
       case SQL_SMALLINT:
       case SQL_TINYINT:
 #if IVSIZE >= 8
-      case SQL_BIGINT:
           buffer_type= MYSQL_TYPE_LONGLONG;
 #else
           buffer_type= MYSQL_TYPE_LONG;
 #endif
           break;
+
+#if IVSIZE >= 8 && !DBD_BIGINT_AS_A_STRING
+      case SQL_BIGINT:
+          buffer_type= MYSQL_TYPE_LONGLONG;
+	  break;
+#endif
       case SQL_DOUBLE:
       case SQL_DECIMAL: 
       case SQL_FLOAT: 


### PR DESCRIPTION
For compatibility reasons it could useful to have the old
behaviour of interpreting BIGINTs as strings.

This could be useful for the following reasons:

* to support code that could potentially run on Perl with `64bitint`
option and without it;

* to be able to treat BIGINTs(from the same source) similarly across
different programming languages without a surprise for the cross-language developers;

* to support existing projects that encode their output(i.e in JSON) to be
processed by services that are strict on decoding format.