### PR TITLE
Add support for mysql zerofill attribute

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -75,6 +75,7 @@ t/lib.pl
 t/manifest.t
 t/mysql.dbtest
 t/pod.t
+t/rt118977-zerofill.t
 t/rt25389-bin-case.t
 t/rt50304-column_info_parentheses.t
 t/rt61849-bind-param-buffer-overflow.t

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3842,6 +3842,9 @@ int dbd_describe(SV* sth, imp_sth_t* imp_sth)
       buffer->is_null= (my_bool*) &(fbh->is_null);
       buffer->error= (my_bool*) &(fbh->error);
 
+      if (fields[i].flags & ZEROFILL_FLAG)
+        buffer->buffer_type = MYSQL_TYPE_STRING;
+
       switch (buffer->buffer_type) {
       case MYSQL_TYPE_DOUBLE:
         buffer->buffer_length= sizeof(fbh->ddata);
@@ -4249,23 +4252,29 @@ process:
 
         switch (mysql_to_perl_type(fields[i].type)) {
         case MYSQL_TYPE_DOUBLE:
-          /* Coerce to dobule and set scalar as NV */
-          (void) SvNV(sv);
-          SvNOK_only(sv);
+          if (!(fields[i].flags & ZEROFILL_FLAG))
+          {
+            /* Coerce to dobule and set scalar as NV */
+            (void) SvNV(sv);
+            SvNOK_only(sv);
+          }
           break;
 
         case MYSQL_TYPE_LONG:
         case MYSQL_TYPE_LONGLONG:
-          /* Coerce to integer and set scalar as UV resp. IV */
-          if (fields[i].flags & UNSIGNED_FLAG)
+          if (!(fields[i].flags & ZEROFILL_FLAG))
           {
-            (void) SvUV(sv);
-            SvIOK_only_UV(sv);
-          }
-          else
-          {
-            (void) SvIV(sv);
-            SvIOK_only(sv);
+            /* Coerce to integer and set scalar as UV resp. IV */
+            if (fields[i].flags & UNSIGNED_FLAG)
+            {
+              (void) SvUV(sv);
+              SvIOK_only_UV(sv);
+            }
+            else
+            {
+              (void) SvIV(sv);
+              SvIOK_only(sv);
+            }
           }
           break;
 

--- a/t/rt118977-zerofill.t
+++ b/t/rt118977-zerofill.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+
+use vars qw($test_dsn $test_user $test_password);
+require "t/lib.pl";
+
+my $dbh = eval { DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 1 }) };
+plan skip_all => "no database connection" if $@ or not $dbh;
+
+plan tests => 4*2;
+
+for my $mysql_server_prepare (0, 1) {
+
+	$dbh->{mysql_server_prepare} = $mysql_server_prepare;
+
+	ok $dbh->do("DROP TABLE IF EXISTS t");
+	ok $dbh->do("CREATE TEMPORARY TABLE t(id smallint(5) unsigned zerofill)");
+	ok $dbh->do("INSERT INTO t(id) VALUES(1)");
+	is $dbh->selectcol_arrayref("SELECT id FROM t")->[0], "00001";
+
+}


### PR DESCRIPTION
Columns with mysql zerofill attribute will be returned as string, because
integer and floating point numbers ignore any leading zeros.

For non-prepared statements just coercion is turned off when received
column has zerofill attribute. For prepared statements when column has
zerofill flag then its type is changed to string. It can be ineffective,
but the only way how we can get all leading zeros from mysql server right
now.