### PR TITLE
Fix support for magic scalars

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -73,6 +73,7 @@ t/90utf8_params.t
 t/91errcheck.t
 t/99_bug_server_prepare_blob_null.t
 t/lib.pl
+t/magic.t
 t/manifest.t
 t/mysql.dbtest
 t/pod.t

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -24,6 +24,26 @@
 #include <errmsg.h> /* Comes with MySQL-devel */
 #include <stdint.h> /* For uint32_t */
 
+#ifndef SvPV_nomg_nolen
+#define SvPV_nomg_nolen(sv) ((SvFLAGS(sv) & (SVf_POK)) == SVf_POK ? SvPVX(sv) : sv_2pv_flags(sv, &PL_na, 0))
+#endif
+
+#ifndef SvTRUE_nomg
+#define SvTRUE_nomg SvTRUE /* SvTRUE does not process get magic for scalars with already cached values, so we are safe */
+#endif
+
+#ifndef SvIV_nomg
+#define SvIV_nomg SvIV /* Sorry, there is no way to handle integer magic scalars properly prior to perl 5.9.1 */
+#endif
+
+#ifndef SvNV_nomg
+#define SvNV_nomg SvNV /* Sorry, there is no way to handle numeric magic scalars properly prior to perl 5.13.2 */
+#endif
+
+#ifndef sv_cmp_flags
+#define sv_cmp_flags(a,b,c) sv_cmp(a,b) /* Sorry, there is no way to compare magic scalars properly prior to perl 5.9.1 */
+#endif
+
 /* For now, we hardcode this, but in the future,
  * we can detect capabilities of the MySQL libraries
  * we're talking to */

--- a/t/magic.t
+++ b/t/magic.t
@@ -1,0 +1,138 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+
+use vars qw($test_dsn $test_user $test_password);
+require "t/lib.pl";
+
+my $tb = Test::More->builder;
+binmode $tb->failure_output, ":utf8";
+binmode $tb->todo_output,    ":utf8";
+
+my $dbh = eval { DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 0, mysql_server_prepare_disable_fallback => 1 }) };
+plan skip_all => "no database connection" if $@ or not $dbh;
+
+plan tests => 288*2;
+
+$dbh->do("CREATE TEMPORARY TABLE t(i INT)");
+
+foreach my $mysql_enable_utf8 (0, 1) {
+    $dbh->{mysql_enable_utf8} = $mysql_enable_utf8;
+    foreach my $mysql_server_prepare (0, 1) {
+        $dbh->{mysql_server_prepare} = $mysql_server_prepare;
+        foreach my $val ('1', 1, 1.0, 1.1, undef, 'XX', "\N{U+100}") {
+            next if defined $val and (my $tmp1 = $val) eq "\N{U+100}" and not $mysql_enable_utf8;
+            {
+                my $param_str = $val;
+                tie my $param, 'TieScalarCounter', $param_str;
+                my $statement_str = "SELECT * FROM t WHERE i = " . $dbh->quote($param_str) . " OR i = ?";
+                tie my $statement, 'TieScalarCounter', $statement_str;
+                my $func = '$dbh->do(' . $statement_str . ', {}, ' . (defined $param_str ? $param_str : 'undef')  . ')';
+                $dbh->do($statement, {}, $param);
+                is(tied($statement)->{fetch}, 1, "$func processes get magic on statement only once");
+                is(tied($statement)->{store}, 0, "$func does not process set magic on statement");
+                is(tied($param)->{fetch}, 1, "$func processes get magic on param only once");
+                is(tied($param)->{store}, 0, "$func does not process set magic on param");
+            }
+            {
+                my $param_str = $val;
+                tie my $param, 'TieScalarCounter', $param_str;
+                my $statement_str = "SELECT * FROM t WHERE i = " . $dbh->quote($param_str) . " OR i = ?";
+                tie my $statement, 'TieScalarCounter', $statement_str;
+                my $func = '$dbh->selectall_arrayref(' . $statement_str . ', {}, ' . (defined $param_str ? $param_str : 'undef')  . ')';
+                $dbh->selectall_arrayref($statement, {}, $param);
+                is(tied($statement)->{fetch}, 1, "$func processes get magic on statement only once");
+                is(tied($statement)->{store}, 0, "$func does not process set magic on statement");
+                is(tied($param)->{fetch}, 1, "$func processes get magic on param only once");
+                is(tied($param)->{store}, 0, "$func does not process set magic on param");
+            }
+            {
+                my $param_str = $val;
+                tie my $param, 'TieScalarCounter', $param_str;
+                my $statement_str = "SELECT * FROM t WHERE i = " . $dbh->quote($param_str) . " OR i = ?";
+                tie my $statement, 'TieScalarCounter', $statement_str;
+                my $func1 = '$dbh->prepare(' . $statement_str . ')';
+                my $func2 = '$sth->execute(' . (defined $param_str ? $param_str : 'undef')  . ')';
+                my $sth = $dbh->prepare($statement);
+                $sth->execute($param);
+                $sth->finish();
+                is(tied($statement)->{fetch}, 1, "$func1 processes get magic on statement only once");
+                is(tied($statement)->{store}, 0, "$func1 does not process set magic on statement");
+                is(tied($param)->{fetch}, 1, "$func2 processes get magic on param only once");
+                is(tied($param)->{store}, 0, "$func2 does not process set magic on param");
+            }
+            {
+                my $param_str = $val;
+                tie my $param, 'TieScalarCounter', $param_str;
+                my $statement_str = "SELECT * FROM t WHERE i = " . $dbh->quote($param_str) . " OR i = ?";
+                tie my $statement, 'TieScalarCounter', $statement_str;
+                my $func1 = '$dbh->prepare(' . $statement_str . ')';
+                my $func2 = '$sth->bind_param(1, ' . (defined $param_str ? $param_str : 'undef')  . ')';
+                my $sth = $dbh->prepare($statement);
+                $sth->bind_param(1, $param);
+                $sth->execute();
+                $sth->finish();
+                is(tied($statement)->{fetch}, 1, "$func1 processes get magic on statement only once");
+                is(tied($statement)->{store}, 0, "$func1 does not process set magic on statement");
+                is(tied($param)->{fetch}, 1, "$func2 processes get magic on param only once");
+                is(tied($param)->{store}, 0, "$func2 does not process set magic on param");
+            }
+            next if defined $val and (my $tmp2 = $val) !~ /^[\d.]+$/;
+            {
+                my $param_str = $val;
+                tie my $param, 'TieScalarCounter', $param_str;
+                my $statement_str = "SELECT * FROM t WHERE i = " . $dbh->quote($param_str) . " OR i = ?";
+                tie my $statement, 'TieScalarCounter', $statement_str;
+                my $func1 = '$dbh->prepare(' . $statement_str . ')';
+                my $func2 = '$sth->bind_param(1, ' . (defined $param_str ? $param_str : 'undef')  . ', DBI::SQL_INTEGER)';
+                my $sth = $dbh->prepare($statement);
+                $sth->bind_param(1, $param, DBI::SQL_INTEGER);
+                $sth->execute();
+                $sth->finish();
+                is(tied($statement)->{fetch}, 1, "$func1 processes get magic on statement only once");
+                is(tied($statement)->{store}, 0, "$func1 does not process set magic on statement");
+                is(tied($param)->{fetch}, 1, "$func2 processes get magic on param only once");
+                is(tied($param)->{store}, 0, "$func2 does not process set magic on param");
+            }
+            {
+                my $param_str = $val;
+                tie my $param, 'TieScalarCounter', $param_str;
+                my $statement_str = "SELECT * FROM t WHERE i = " . $dbh->quote($param_str) . " OR i = ?";
+                tie my $statement, 'TieScalarCounter', $statement_str;
+                my $func1 = '$dbh->prepare(' . $statement_str . ')';
+                my $func2 = '$sth->bind_param(1, ' . (defined $param_str ? $param_str : 'undef')  . ', DBI::SQL_FLOAT)';
+                my $sth = $dbh->prepare($statement);
+                $sth->bind_param(1, $param, DBI::SQL_FLOAT);
+                $sth->execute();
+                $sth->finish();
+                is(tied($statement)->{fetch}, 1, "$func1 processes get magic on statement only once");
+                is(tied($statement)->{store}, 0, "$func1 does not process set magic on statement");
+                is(tied($param)->{fetch}, 1, "$func2 processes get magic on param only once");
+                is(tied($param)->{store}, 0, "$func2 does not process set magic on param");
+            }
+        }
+    }
+}
+
+$dbh->disconnect();
+
+package TieScalarCounter;
+
+sub TIESCALAR {
+    my ($class, $value) = @_;
+    return bless { fetch => 0, store => 0, value => $value }, $class;
+}
+
+sub FETCH {
+    my ($self) = @_;
+    $self->{fetch}++;
+    return $self->{value};
+}
+
+sub STORE {
+    my ($self, $value) = @_;
+    $self->{store}++;
+    $self->{value} = $value;
+}

--- a/t/magic.t
+++ b/t/magic.t
@@ -93,7 +93,10 @@ foreach my $mysql_enable_utf8 (0, 1) {
                 $sth->finish();
                 is(tied($statement)->{fetch}, 1, "$func1 processes get magic on statement only once");
                 is(tied($statement)->{store}, 0, "$func1 does not process set magic on statement");
-                is(tied($param)->{fetch}, 1, "$func2 processes get magic on param only once");
+                SKIP: {
+                    skip('Passing magic scalar to bind_param() with DBI::SQL_INTEGER process get magic more times prior to perl 5.15.4', 1) if $] < 5.015004;
+                    is(tied($param)->{fetch}, 1, "$func2 processes get magic on param only once");
+                }
                 is(tied($param)->{store}, 0, "$func2 does not process set magic on param");
             }
             {
@@ -109,7 +112,10 @@ foreach my $mysql_enable_utf8 (0, 1) {
                 $sth->finish();
                 is(tied($statement)->{fetch}, 1, "$func1 processes get magic on statement only once");
                 is(tied($statement)->{store}, 0, "$func1 does not process set magic on statement");
-                is(tied($param)->{fetch}, 1, "$func2 processes get magic on param only once");
+                SKIP: {
+                    skip('Passing magic scalar to bind_param() with DBI::SQL_FLOAT process get magic more times prior to perl 5.15.4', 1) if $] < 5.015004;
+                    is(tied($param)->{fetch}, 1, "$func2 processes get magic on param only once");
+                }
                 is(tied($param)->{store}, 0, "$func2 does not process set magic on param");
             }
         }


### PR DESCRIPTION
In every XS function process get magic only once.

Perl versions prior to 5.13.2 will be still broken because of missing _nomg
variants of perl functions.