### PR TITLE
Basic GTID tracking.

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2854,6 +2854,28 @@ SV* dbd_db_FETCH_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv)
       result= sv_2mortal((newRV_noinc((SV*)hv)));
     }
 
+#if MYSQL_VERSION_ID >= 50708
+#if MYSQL_VERSION_ID != 60000 /* Connector/C 6.0.x */
+#ifndef MARIADB_BASE_VERSION
+/* SESSION_TRACK_GTIDS was added in commit c4f32d662 in MySQL 5.7.8-rc */
+  case 'g':
+    if (strEQ(key, "gtids"))
+    {
+      const char *data;
+      size_t length;
+      if (mysql_session_track_get_first(imp_dbh->pmysql, SESSION_TRACK_GTIDS, &data, &length) == 0)
+      {
+        result= sv_2mortal(newSVpvn(data, length));
+      }
+      else
+      {
+        result= &PL_sv_undef;
+      }
+    }
+    break;
+#endif
+#endif
+#endif
   case 'h':
     if (strEQ(key, "hostinfo"))
     {

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1728,6 +1728,11 @@ this attribute determines whether a I<fetchrow> will chop preceding
 and trailing blanks off the column values. Chopping blanks does not
 have impact on the I<max_length> attribute.
 
+=item mysql_gtids
+
+Returns GTID(s) if GTID session tracking is ensabled in the server via
+session_track_gtids.
+
 =item mysql_insertid
 
 If the statement you executed performs an INSERT, and there is an AUTO_INCREMENT

--- a/t/57trackgtid.t
+++ b/t/57trackgtid.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+
+use vars qw($test_dsn $test_user $test_password);
+use lib 't', '.';
+require "lib.pl";
+
+my $dbh;
+eval{$dbh = DBI->connect($test_dsn, $test_user, $test_password,
+			    {RaiseError => 1});};
+
+if ($@) {
+    plan skip_all =>
+        "no database connection";
+}
+
+my @gtidtrackenabled = $dbh->selectrow_array('select @@global.session_track_gtids');
+if (!@gtidtrackenabled) {
+  plan skip_all => 'GTID tracking not available';
+} elsif ($gtidtrackenabled[0] eq 'OFF') {
+  plan skip_all => 'GTID tracking not enabled';
+} else {
+  plan tests => 2;
+}
+
+$dbh->do('FLUSH PRIVILEGES');
+cmp_ok(length($dbh->{'mysql_gtids'}),'>=',38);
+
+ok $dbh->disconnect();


### PR DESCRIPTION
https://rt.cpan.org/Public/Bug/Display.html?id=119122
https://dev.mysql.com/doc/refman/5.7/en/mysql-session-track-get-first.html

This code is only tested at a *very* basic level.

- The test runs, but other tests fail on a GTID enabled server. For example: 
```
t/53comment.t ........................... DBD::mysql::db do failed: Statement violates GTID consistency: CREATE TEMPORARY TABLE and DROP TEMPORARY TABLE can only be executed outside transactional context.  These statements are also not allowed in a function or trigger because functions and triggers are also considered to be multi-statement transactions. at t/53comment.t line 32.
```
- This is specific for GTID tracking and doesn't to schema/state/variable tracking. This could be made in a more generic feature, but currently I think this more specific feature makes sense.
- This is tested against 5.7 and it *should* be possible to compile it against 5.6 and below (with loss of function)
- I did not test against MariaDB server
- I did not test compilation against MariaDB libraries
- It probably works against MariaDB: https://jira.mariadb.org/browse/MDEV-8931
- MariaDB has a different GTID implementation, so it might behave differently (e.g. test might fail because the MariaDB implementation has a shorter GTID)
- The test only runs against a server were this is enabled in the config, so this gets very limited testing. Unfortunately this can't be enabled dynamically, so we can't enable it during the test.

Example:
```perl
#!/usr/bin/perl
use v5.24.0;
use DBI;

my $dbh = DBI->connect("DBI:mysql:database=test;mysql_socket=/tmp/mysql_sandbox5717.sock",
                       "msandbox", "msandbox",
                       {'RaiseError' => 1});

$dbh->do('FLUSH PRIVILEGES');
say "GTID= $dbh->{'mysql_gtids'}";

$dbh->disconnect();
```