### PR TITLE
Fix parsing configure libs from mysql_config --libs output in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -578,7 +578,7 @@ sub Configure {
                 if ($param eq 'libs') {
                     my (@libs, @ldflags);
                     for (split ' ', $str) {
-                        if (/^-[Ll]/) { push @libs, $_ }
+                        if (/^-[Ll]/ || /^[^\-]/) { push @libs, $_ }
                         else          { push @ldflags, $_ }
                     }
                     $str = "@libs";


### PR DESCRIPTION
Libraries in mysql_config --libs output can be specified by library name
with -l prefix or by absolute path to library name without any prefix.
Parameters must start with a hyphen, so treat all options without leading
hyphen in mysql_config --libs output as libraries with full path.

Partially fix bug: https://rt.cpan.org/Public/Bug/Display.html?id=100898