### PR TITLE
Run travis tests on different MySQL and MariaDB versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ perl:
   - "5.14"
   - "5.16"
   - "5.18"
+  - "5.18-shrplib"
   - "5.20"
+  - "5.20-shrplib"
   - "5.22"
+  - "5.22-shrplib"
   - "5.24"
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,100 @@ perl:
   - "5.20"
   - "5.22"
   - "5.24"
+matrix:
+  include:
+    - perl: "5.20"
+      env: DB=MySQL VERSION=4.1.22
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.0.15
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.0.96
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.1.30
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.1.72
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.5.8
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.5.47
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.5.54
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.6.10
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.6.30
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.6.35
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.7.8-rc
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.7.17
+    - perl: "5.20"
+      env: DB=MySQL VERSION=8.0.0-dmr
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=5.5.40
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=5.5.47
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=5.5.54
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=10.0.14
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=10.0.29
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=10.1.2
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=10.1.8
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=10.1.20
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=10.2.0
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=10.2.1
 before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq libmysqlclient-dev libmysqld-dev libwrap0-dev
- - perlbrew install-cpanm -f
+  - if [ "$DB" = "MySQL" ]; then
+      case "$VERSION" in
+        4.1.*)       SANDBOX_URL=http://mysql.localhost.net.ar/Downloads/MySQL-4.1/mysql-standard-$VERSION-unknown-linux-gnu-x86_64-glibc23.tar.gz ;;
+        5.0.[012]*)  SANDBOX_URL=https://downloads.mysql.com/archives/get/file/mysql-standard-$VERSION-linux-x86_64-glibc23.tar.gz ;;
+        5.[01].*)    SANDBOX_URL=https://downloads.mysql.com/archives/get/file/mysql-$VERSION-linux-x86_64-glibc23.tar.gz ;;
+        5.5.*)       SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux2.6-x86_64.tar.gz ;;
+        5.[67].*)    SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux-glibc2.5-x86_64.tar.gz ;;
+        8.0.*)       SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux-glibc2.12-x86_64.tar.gz ;;
+        *)           echo "Unsupported MySQL version '$VERSION'"; exit 1 ;;
+      esac ;
+      SANDBOX_FILE="$HOME/$(basename "$SANDBOX_URL")" ;
+    elif [ "$DB" = "MariaDB" ]; then
+      SANDBOX_URL=https://downloads.mariadb.org/interstitial/mariadb-$VERSION/bintar-linux-x86_64/mariadb-$VERSION-linux-x86_64.tar.gz/from/http%3A//ftp.hosteurope.de/mirror/archive.mariadb.org/ ;
+      SANDBOX_FILE="$HOME/mariadb-$VERSION-linux-x86_64.tar.gz" ;
+    elif [ -n "$DB" ]; then
+      echo "Unsupported DB '$DB'"; exit 1 ;
+    fi
+  - if [ -n "$DB" ]; then
+      export SANDBOX_HOME="$HOME/sandbox" ;
+      export SANDBOX_BINARY="$SANDBOX_HOME/binary" ;
+      wget "$SANDBOX_URL" -O "$SANDBOX_FILE" || exit 1 ;
+    fi
+  - sudo apt-get update -qq
+  - if [ -n "$DB" ]; then
+      sudo apt-get install -qq libaio-dev libnuma-dev libjemalloc-dev || exit 1 ;
+      sudo apt-get remove -qq mysql-client mysql-client-5.5 mysql-client-core-5.5 mysql-common mysql-server mysql-server-5.5 mysql-server-core-5.5 libmysqlclient-dev libmysqlclient18 || exit 1 ;
+    else
+      sudo apt-get install -qq libmysqlclient-dev libmysqld-dev libwrap0-dev || exit 1 ;
+    fi
+  - perlbrew install-cpanm -f
 install:
   - cpanm --quiet DBI Test::Pod Test::Deep Test::DistManifest Proc::ProcessTable Devel::CheckLib
-script: "export RELEASE_TESTING=1 && perl Makefile.PL && make disttest && perl Makefile.PL --force-embedded && make disttest"
+  - if [ -n "$DB" ]; then
+      cpanm --quiet MySQL::Sandbox || exit 1 ;
+      make_sandbox --export_binaries "$SANDBOX_FILE" -- --sandbox_port 3310 --sandbox_directory msb --no_confirm || exit 1 ;
+      printf '%s\n%s\n' '#!/bin/sh' 'exec "$SANDBOX_HOME/msb/my" sql_config "$@"' > "$SANDBOX_HOME/msb/mysql_config" || exit 1 ;
+      chmod +x "$SANDBOX_HOME/msb/mysql_config" || exit 1 ;
+    fi
+  - export RELEASE_TESTING=1
+script:
+  - if [ -n "$DB" ]; then
+      perl Makefile.PL --mysql_config="$SANDBOX_HOME/msb/mysql_config" --testuser=msandbox --testpassword=msandbox --testhost=127.0.0.1 --testport=3310 && make disttest || exit 1;
+    else
+      perl Makefile.PL && make disttest || exit 1 ;
+      perl Makefile.PL --force-embedded && make disttest || exit 1 ;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_install:
  - sudo apt-get install -qq libmysqlclient-dev libmysqld-dev libwrap0-dev
  - perlbrew install-cpanm -f
 install:
-  - cpanm --quiet DBI Test::Pod Test::Deep Test::DistManifest Proc::ProcessTable
+  - cpanm --quiet DBI Test::Pod Test::Deep Test::DistManifest Proc::ProcessTable Devel::CheckLib
 script: "export RELEASE_TESTING=1 && perl Makefile.PL && make disttest && perl Makefile.PL --force-embedded && make disttest"

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,6 +9,7 @@ use Config;
 use Getopt::Long;
 use ExtUtils::MakeMaker;
 use Data::Dumper;
+use Devel::CheckLib;
 use File::Path;
 use File::Copy;
 use File::Basename;
@@ -204,6 +205,29 @@ To change these settings, see 'perl Makefile.PL --help' and
 'perldoc DBD::mysql::INSTALL'.
 
 MSG
+
+print "Checking if settings can be used for compiling...\n";
+
+print "\nWarning: This check may fail. If it happens please upgrade\n         Devel::CheckLib to version 1.07 and try again.\n\n"
+  if $Devel::CheckLib::VERSION < 1.07;
+
+assert_lib(
+  header => [ 'mysql.h', 'mysqld_error.h', 'errmsg.h' ],
+  LIBS => ($opt->{'embedded'} ? $opt->{'embedded'} : $opt->{libs}),
+  $Devel::CheckLib::VERSION >= 1.07 ? (
+    ccflags => $opt->{cflags} . (
+      # NOTE: Windows version of mysql.h cannot be compiled without SOCKET type (which is unsigned integer of pointer size)
+      ($^O eq 'MSWin32') ? ' -DSOCKET="unsigned long int"' : ''
+    ),
+    $opt->{ldflags} ? (ldflags => $opt->{ldflags}) : (),
+  ) : (
+    # NOTE: Devel::CheckLib prior to 1.07 does not support passing cflags and ldflags
+    #       We just pass incpaths prefixed by -I via INC
+    INC => join(" ", grep /^-I/, split / /, $opt->{cflags}),
+  ),
+);
+
+print "Looks good.\n\n";
 
 sleep 1;
 
@@ -451,6 +475,7 @@ if (eval $ExtUtils::MakeMaker::VERSION >= 5.43) {
     },
     CONFIGURE_REQUIRES => { 'DBI' => 1.609,
                             'Data::Dumper' => 0,
+                            'Devel::CheckLib' => 0,
     },
   );
 }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,7 @@ my $TESTDB = "test";
 our $opt = { "help" => \&Usage, };
 
 {
-local ($::test_host, $::test_port, $::test_user, $::test_socket, $::test_password, $::test_db, $::test_force_embedded);
+local ($::test_host, $::test_port, $::test_user, $::test_socket, $::test_password, $::test_db, $::test_force_embedded, $::test_mysql_config);
 eval { require "t/mysql.mtest"; 1; } || eval { require "../t/mysql.mtest"; 1; } and do {
 $opt->{'testhost'} = $::test_host;
 $opt->{'testport'} = $::test_port;
@@ -29,6 +29,7 @@ $opt->{'testsocket'} = $::test_socket;
 $opt->{'testpassword'} = $::test_password;
 $opt->{'testdb'} = $::test_db;
 $opt->{'force-embedded'} = $::test_force_embedded if $::test_force_embedded;
+$opt->{'mysql_config'} = $::test_mysql_config;
 }
 }
 
@@ -72,7 +73,7 @@ my $source = {};
   {
     $opt->{'mysql_config'} = Win32::GetShortPathName($opt->{'mysql_config'})
         if $^O eq 'MSWin32';
-    if (!-f $opt->{'mysql_config'})
+    if (! defined `$opt->{'mysql_config'} --version`)
     {
       print <<"MSG";
 
@@ -228,6 +229,7 @@ my $fileName = $@ ?
               "\$::test_dsn .= \":\$::test_host\" if \$::test_host;\n" .
 	      "\$::test_dsn .= \":\$::test_port\" if \$::test_port;\n".
 	      "\$::test_force_embedded = \$opt->{'force-embedded'} if \$opt->{'force-embedded'};\n" .
+	      "\$::test_mysql_config = \$opt->{'mysql_config'};\n" .
               $dsn .
 	      "} 1;\n"))  &&
   close(FILE))  ||  die "Failed to create $fileName: $!";

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ install:
   - perl -V
   - cpan App::cpanminus
   - cpanm -q --showdeps --with-develop --with-suggests . | findstr /v "^perl\>" | cpanm -n
+  - cpanm -q -n Devel::CheckLib
 
 build_script:
   - perl Makefile.PL --mysql_config=c:\strawberry\c\bin\mysql_config.bat --testuser=root --testpassword=Password12!


### PR DESCRIPTION
Changes in this pull request:
* Remember mysql_config value for Makefile.PL
* Check if specified Makefile.PL settings are working
* Run travis tests on different MySQL and MariaDB versions
* Run travis tests also on perl versions with -Duseshrplib

____

Travis matrix contains different MySQL and MariaDB version, namely those
which are available in stable long term supported Linux distributions.

Config file is prepared for easily extending database server matrix once
new versions are released.

Travis downloads official MySQL or MariaDB binary tarball and uses
MySQL::Sandbox for starting database server. DBD::mysql is then compiled
against client provided by that tarball and pre-installed perl 5.20 by
Travis.

Other perl versions are tested against system pre-installed database
version as before.