### PR TITLE
Fix unit tests for different MySQL and MariaDB versions

### DIFF
--- a/t/29warnings.t
+++ b/t/29warnings.t
@@ -17,8 +17,8 @@ if ($@) {
     plan skip_all => "no database connection";
 }
 
-if ( !MinimumVersion($dbh, '4.1') ) {
-    plan skip_all => "Servers < 4.1 do not report warnings";
+if ($dbh->{mysql_serverversion} < 40101) {
+    plan skip_all => "Servers < 4.1.1 do not report warnings";
 }
 
 my $expected_warnings = 1;

--- a/t/29warnings.t
+++ b/t/29warnings.t
@@ -21,9 +21,9 @@ if ($dbh->{mysql_serverversion} < 40101) {
     plan skip_all => "Servers < 4.1.1 do not report warnings";
 }
 
-my $expected_warnings = 1;
-if ( MinimumVersion($dbh, '5.5') ) {
-    $expected_warnings = 2;
+my $expected_warnings = 2;
+if ($dbh->{mysql_serverversion} >= 50000 && $dbh->{mysql_serverversion} < 50500) {
+    $expected_warnings = 1;
 }
 
 plan tests => 14;

--- a/t/31insertid.t
+++ b/t/31insertid.t
@@ -18,8 +18,11 @@ if ($@) {
 }
 plan tests => 19;
 
-ok $dbh->do('SET @@auto_increment_offset = 1');
-ok $dbh->do('SET @@auto_increment_increment = 1');
+SKIP: {
+    skip 'SET @@auto_increment_offset needs MySQL >= 5.0.2', 2 unless $dbh->{mysql_serverversion} >= 50002;
+    ok $dbh->do('SET @@auto_increment_offset = 1');
+    ok $dbh->do('SET @@auto_increment_increment = 1');
+}
 
 my $create = <<EOT;
 CREATE TEMPORARY TABLE dbd_mysql_t31 (

--- a/t/40bindparam.t
+++ b/t/40bindparam.t
@@ -15,7 +15,6 @@ if ($@) {
 }
 
 if (!MinimumVersion($dbh, '4.1')) {
-    plan skip_all => "ERROR: $DBI::errstr. Can't continue test";
     plan skip_all =>
         "SKIP TEST: You must have MySQL version 4.1 and greater for this test to run";
 }

--- a/t/40bindparam2.t
+++ b/t/40bindparam2.t
@@ -16,8 +16,11 @@ if ($@) {
 }
 plan tests => 13;
 
-ok $dbh->do('SET @@auto_increment_offset = 1');
-ok $dbh->do('SET @@auto_increment_increment = 1');
+SKIP: {
+    skip 'SET @@auto_increment_offset needs MySQL >= 5.0.2', 2 unless $dbh->{mysql_serverversion} >= 50002;
+    ok $dbh->do('SET @@auto_increment_offset = 1');
+    ok $dbh->do('SET @@auto_increment_increment = 1');
+}
 
 my $create= <<EOT;
 CREATE TEMPORARY TABLE dbd_mysql_t40bindparam2 (

--- a/t/40bit.t
+++ b/t/40bit.t
@@ -19,13 +19,12 @@ eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
 if ($@) {
     plan skip_all => "no database connection";
 }
-else {
-    plan tests => 15;
+
+if ($dbh->{mysql_serverversion} < 50008) {
+    plan skip_all => "Servers < 5.0.8 do not support b'' syntax";
 }
 
-if (!MinimumVersion($dbh, '4.1')) {
-    $charset= '';
-}
+plan tests => 15;
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_b1"), "Drop table if exists dbd_mysql_b1";
 

--- a/t/40server_prepare.t
+++ b/t/40server_prepare.t
@@ -18,6 +18,11 @@ eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
 if ($@) {
     plan skip_all => "no database connection";
 }
+
+if ($dbh->{mysql_clientversion} < 40103 or $dbh->{mysql_serverversion} < 40103) {
+    plan skip_all => "You must have MySQL version 4.1.3 and greater for this test to run";
+}
+
 plan tests => 31;
 
 ok(defined $dbh, "connecting");

--- a/t/40server_prepare_crash.t
+++ b/t/40server_prepare_crash.t
@@ -9,6 +9,7 @@ require "t/lib.pl";
 
 my $dbh = eval { DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 1, AutoCommit => 0, mysql_server_prepare => 1, mysql_server_prepare_disable_fallback => 1 }) };
 plan skip_all => "no database connection" if $@ or not $dbh;
+plan skip_all => "You must have MySQL version 4.1.3 and greater for this test to run" if $dbh->{mysql_clientversion} < 40103 or $dbh->{mysql_serverversion} < 40103;
 
 plan tests => 39;
 

--- a/t/40server_prepare_error.t
+++ b/t/40server_prepare_error.t
@@ -17,13 +17,9 @@ if ($@) {
     plan skip_all => "no database connection";
 }
 
-#
-# DROP/CREATE PROCEDURE will give syntax error
-# for versions < 5.0
-#
-if (!MinimumVersion($dbh, '4.1')) {
+if ($dbh->{mysql_clientversion} < 40103 or $dbh->{mysql_serverversion} < 40103) {
     plan skip_all =>
-        "SKIP TEST: You must have MySQL version 4.1 and greater for this test to run";
+        "SKIP TEST: You must have MySQL version 4.1.3 and greater for this test to run";
 }
 plan tests => 3;
 

--- a/t/41int_min_max.t
+++ b/t/41int_min_max.t
@@ -17,7 +17,6 @@ if ($@) {
 }
 
 if (!MinimumVersion($dbh, '4.1')) {
-    plan skip_all => "ERROR: $DBI::errstr. Can't continue test";
     plan skip_all =>
         "SKIP TEST: You must have MySQL version 4.1 and greater for this test to run";
 }

--- a/t/41int_min_max.t
+++ b/t/41int_min_max.t
@@ -16,9 +16,9 @@ if ($@) {
     plan skip_all => "no database connection";
 }
 
-if (!MinimumVersion($dbh, '4.1')) {
+if ($dbh->{mysql_serverversion} < 50002) {
     plan skip_all =>
-        "SKIP TEST: You must have MySQL version 4.1 and greater for this test to run";
+        "SKIP TEST: You must have MySQL version 5.0.2 and greater for this test to run";
 }
 # nostrict tests + strict tests + init/tear down commands
 plan tests => (19*8 + 17*8 + 4) * 2;

--- a/t/50chopblanks.t
+++ b/t/50chopblanks.t
@@ -14,6 +14,9 @@ eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
 if ($@) {
     plan skip_all => "no database connection";
 }
+if ($dbh->{mysql_serverversion} < 40103) {
+    plan skip_all => "You must have MySQL version 4.1.3 and greater for this test to run";
+}
 plan tests => 36 * 2;
 
 for my $mysql_server_prepare (0, 1) {

--- a/t/50chopblanks.t
+++ b/t/50chopblanks.t
@@ -28,7 +28,7 @@ ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t50chopblanks"), "drop table if exis
 my $create= <<EOT;
 CREATE TABLE dbd_mysql_t50chopblanks (
   id INT(4),
-  name VARCHAR(64)
+  name TEXT
 )
 EOT
 

--- a/t/55utf8.t
+++ b/t/55utf8.t
@@ -18,7 +18,7 @@ if ($@) {
 #
 # DROP/CREATE PROCEDURE will give syntax error for these versions
 #
-if (!MinimumVersion($dbh, '5.0')) {
+if ($dbh->{mysql_serverversion} < 50000) {
     plan skip_all =>
         "SKIP TEST: You must have MySQL version 5.0 and greater for this test to run";
 }

--- a/t/55utf8.t
+++ b/t/55utf8.t
@@ -89,7 +89,10 @@ ok $sth->finish;
 cmp_ok($dbh->{mysql_warning_count}, '==', 1, 'got warning for INSERT') or do { diag("SHOW WARNINGS:"); diag($_->[2]) foreach @{$dbh->selectall_arrayref("SHOW WARNINGS", { mysql_server_prepare => 0 })}; };
 cmp_ok($dbh->selectrow_arrayref("SHOW WARNINGS", { mysql_server_prepare => 0 })->[2], 'eq', 'Incorrect string value: \'\xC4\x80dam\' for column \'ascii\' at row 1');
 
-$query = "SELECT name,bincol,asbinary(shape), binutf, profile, str2, ascii, latin FROM dbd_mysql_t55utf8 LIMIT 1";
+# AsBinary() is deprecated as of MySQL 5.7.6, use ST_AsBinary() instead
+my $asbinary = $dbh->{mysql_serverversion} >= 50706 ? 'ST_AsBinary' : 'AsBinary';
+
+$query = "SELECT name,bincol,$asbinary(shape), binutf, profile, str2, ascii, latin FROM dbd_mysql_t55utf8 LIMIT 1";
 $sth = $dbh->prepare($query) or die "$DBI::errstr";
 
 ok $sth->execute;

--- a/t/55utf8.t
+++ b/t/55utf8.t
@@ -87,7 +87,7 @@ ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
 ok $sth->finish;
 
 cmp_ok($dbh->{mysql_warning_count}, '==', 1, 'got warning for INSERT') or do { diag("SHOW WARNINGS:"); diag($_->[2]) foreach @{$dbh->selectall_arrayref("SHOW WARNINGS", { mysql_server_prepare => 0 })}; };
-cmp_ok($dbh->selectrow_arrayref("SHOW WARNINGS", { mysql_server_prepare => 0 })->[2], 'eq', 'Incorrect string value: \'\xC4\x80dam\' for column \'ascii\' at row 1');
+like($dbh->selectrow_arrayref("SHOW WARNINGS", { mysql_server_prepare => 0 })->[2], qr/^(?:Incorrect string value: '\\xC4\\x80dam'|Data truncated) for column 'ascii' at row 1$/);
 
 # AsBinary() is deprecated as of MySQL 5.7.6, use ST_AsBinary() instead
 my $asbinary = $dbh->{mysql_serverversion} >= 50706 ? 'ST_AsBinary' : 'AsBinary';

--- a/t/55utf8mb4.t
+++ b/t/55utf8mb4.t
@@ -14,14 +14,16 @@ if ($@) {
     plan skip_all => "no database connection";
 }
 
-$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
-
-eval {$dbh->do("SET NAMES 'utf8mb4'");};
-if ($@) {
+eval {
+   $dbh->{PrintError} = 0;
+   $dbh->do("SET NAMES 'utf8mb4'");
+   $dbh->{PrintError} = 1;
+   1;
+} or do {
    $dbh->disconnect();
    plan skip_all => "no support for utf8mb4";
-}
+};
+
 ok $dbh->do("CREATE TEMPORARY TABLE dbd_mysql_t55utf8mb4 (id SERIAL, val TEXT CHARACTER SET utf8mb4)");
 
 my $sth = $dbh->prepare("INSERT INTO dbd_mysql_t55utf8mb4(val) VALUES('😈')");

--- a/t/76multi_statement.t
+++ b/t/76multi_statement.t
@@ -27,6 +27,9 @@ SKIP: {
   skip "Server doesn't support multi statements", 25
   if $dbh->{mysql_clientversion} < 40101 or $dbh->{mysql_serverversion} < 40101;
 
+  skip "Server has deadlock bug 16581", 25
+  if $dbh->{mysql_clientversion} < 50025 or ($dbh->{mysql_serverversion} >= 50100 and $dbh->{mysql_serverversion} < 50112);
+
   ok($dbh->do("SET SQL_MODE=''"),"init connection SQL_MODE non strict");
 
   ok($dbh->do("DROP TABLE IF EXISTS dbd_mysql_t76multi"), "clean up");

--- a/t/76multi_statement.t
+++ b/t/76multi_statement.t
@@ -24,8 +24,8 @@ ok (defined $dbh, "Connected to database with multi statement support");
 $dbh->{mysql_server_prepare}= 0;
 
 SKIP: {
-  skip "Server doesn't support multi statements", 24
-  if !MinimumVersion($dbh, '4.1');
+  skip "Server doesn't support multi statements", 25
+  if $dbh->{mysql_clientversion} < 40101 or $dbh->{mysql_serverversion} < 40101;
 
   ok($dbh->do("SET SQL_MODE=''"),"init connection SQL_MODE non strict");
 

--- a/t/80procs.t
+++ b/t/80procs.t
@@ -20,7 +20,7 @@ if ($@) {
 # DROP/CREATE PROCEDURE will give syntax error
 # for versions < 5.0
 #
-if (!MinimumVersion($dbh, '5.0') ) {
+if ($dbh->{mysql_serverversion} < 50000) {
     plan skip_all =>
         "You must have MySQL version 5.0 and greater for this test to run";
 }

--- a/t/81procs.t
+++ b/t/81procs.t
@@ -20,7 +20,7 @@ if ($@) {
 # DROP/CREATE PROCEDURE will give syntax error
 # for versions < 5.0
 #
-if (!MinimumVersion($dbh, '5.0')) {
+if ($dbh->{mysql_serverversion} < 50000) {
     plan skip_all =>
         "You must have MySQL version 5.0 and greater for this test to run";
 }

--- a/t/87async.t
+++ b/t/87async.t
@@ -17,6 +17,9 @@ eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
 if (!$dbh) {
     plan skip_all => "no database connection";
 }
+if ($dbh->{mysql_serverversion} < 50012) {
+    plan skip_all => "Servers < 5.0.12 do not support SLEEP()";
+}
 unless($dbh->get_info($GetInfoType{'SQL_ASYNC_MODE'})) {
     plan skip_all => "Async support wasn't built into this version of DBD::mysql";
 }

--- a/t/87async.t
+++ b/t/87async.t
@@ -53,7 +53,7 @@ ok(($end - $start) >= 2);
 
 $start = Time::HiRes::gettimeofday();
 $rows = $dbh->do('INSERT INTO async_test VALUES (SLEEP(2), 0, 0)', { async => 1 });
-ok defined($dbh->mysql_async_ready);
+ok(defined($dbh->mysql_async_ready)) or die;
 $end = Time::HiRes::gettimeofday();
 
 ok $rows;

--- a/t/90utf8_params.t
+++ b/t/90utf8_params.t
@@ -18,7 +18,7 @@ require 'lib.pl';
 my $dbh = eval { DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1 }) } or
     plan skip_all => "no database connection";
 
-if ($dbh->get_info($GetInfoType{SQL_DBMS_VER}) lt "5.0") {
+if ($dbh->{mysql_serverversion} < 50000) {
     plan skip_all => "You must have MySQL version 5.0 and greater for this test to run";
 }
 

--- a/t/rt50304-column_info_parentheses.t
+++ b/t/rt50304-column_info_parentheses.t
@@ -15,8 +15,10 @@ if ($@) {
     plan skip_all => "no database connection";
 }
 
+ok($dbh->do("DROP TABLE IF EXISTS dbd_mysql_rt50304_column_info"));
+
 my $create = <<EOC;
-CREATE TEMPORARY TABLE dbd_mysql_rt50304_column_info (
+CREATE TABLE dbd_mysql_rt50304_column_info (
     id int(10)unsigned NOT NULL AUTO_INCREMENT,
     problem_column SET('','(Some Text)') DEFAULT NULL,
     regular_column SET('','Some Text') DEFAULT NULL,
@@ -25,7 +27,7 @@ CREATE TEMPORARY TABLE dbd_mysql_rt50304_column_info (
 );
 EOC
 
-ok $dbh->do($create), "create temporary table dbd_mysql_rt50304_column_info";
+ok($dbh->do($create), "create table dbd_mysql_rt50304_column_info");
 
 my $sth = $dbh->column_info(undef, undef, 'dbd_mysql_rt50304_column_info', 'problem_column');
 my $info = $sth->fetchall_arrayref({});
@@ -38,5 +40,7 @@ $info = $sth->fetchall_arrayref({});
 is ( scalar @{$info->[0]->{mysql_values}}, 2, 'regular_column values');
 is ( $info->[0]->{mysql_values}->[0], '', 'regular_column first value');
 is ( $info->[0]->{mysql_values}->[1], 'Some Text', 'regular_column second value');
+
+ok($dbh->do("DROP TABLE dbd_mysql_rt50304_column_info"));
 ok($dbh->disconnect());
 done_testing;

--- a/t/rt75353-innodb-lock-timeout.t
+++ b/t/rt75353-innodb-lock-timeout.t
@@ -41,12 +41,16 @@ if (!$have_innodb) {
   plan skip_all => "Server doesn't support InnoDB, needed for testing innodb_lock_wait_timeout";
 }
 
-eval {$dbh2->do("SET innodb_lock_wait_timeout=1");};
-if ($@) {
+eval {
+  $dbh2->{PrintError} = 0;
+  $dbh2->do("SET innodb_lock_wait_timeout=1");
+  $dbh2->{PrintError} = 1;
+  1;
+} or do {
   $dbh1->disconnect();
   $dbh2->disconnect();
   plan skip_all => "innodb_lock_wait_timeout is not modifyable on this version of MySQL";
-}
+};
 
 ok $dbh1->do("DROP TABLE IF EXISTS dbd_mysql_rt75353_innodb_lock_timeout"), "drop table if exists dbd_mysql_rt75353_innodb_lock_timeout";
 ok $dbh1->do("CREATE TABLE dbd_mysql_rt75353_innodb_lock_timeout(id INT PRIMARY KEY) ENGINE=INNODB"), "create table dbd_mysql_rt75353_innodb_lock_timeout";

--- a/t/rt88006-bit-prepare.t
+++ b/t/rt88006-bit-prepare.t
@@ -21,6 +21,10 @@ if ($@) {
   plan skip_all => "no database connection";
 }
 
+if ($dbh->{mysql_serverversion} < 50008) {
+  plan skip_all => "Servers < 5.0.8 do not support b'' syntax";
+}
+
 my $create = <<EOT;
 CREATE TEMPORARY TABLE `dbd_mysql_rt88006_bit_prep` (
   `id` bigint(20) NOT NULL auto_increment,

--- a/t/rt88006-bit-prepare.t
+++ b/t/rt88006-bit-prepare.t
@@ -25,6 +25,10 @@ if ($dbh->{mysql_serverversion} < 50008) {
   plan skip_all => "Servers < 5.0.8 do not support b'' syntax";
 }
 
+if ($dbh->{mysql_serverversion} < 50026) {
+  plan skip_all => "Servers < 5.0.26 do not support BIN() for BIT values";
+}
+
 my $create = <<EOT;
 CREATE TEMPORARY TABLE `dbd_mysql_rt88006_bit_prep` (
   `id` bigint(20) NOT NULL auto_increment,


### PR DESCRIPTION
Tests were fixed to correctly check for server or client versions (what is needed). Function MinimumVersion or attribute SQL_DBMS_VER do not work correctly as those returns strings which include also database server name (e.g. MariaDB vs MySQL).

Some tests are completely skipped if they depends on features not available in current tested MySQL server. And some tests were fixes to work with older and also newer MySQL and MariaDB versions as some function names was deprecated/renamed/removed.

With these changes all unit tests tested against MySQL and MariaDB versions in https://github.com/perl5-dbi/DBD-mysql/pull/85 are passing.