### PR TITLE
Check only for libs via Devel::CheckLib in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -206,25 +206,10 @@ To change these settings, see 'perl Makefile.PL --help' and
 
 MSG
 
-print "Checking if settings can be used for compiling...\n";
-
-print "\nWarning: This check may fail. If it happens please upgrade\n         Devel::CheckLib to version 1.07 and try again.\n\n"
-  if $Devel::CheckLib::VERSION < 1.07;
+print "Checking if libs are available for compiling...\n";
 
 assert_lib(
-  header => [ 'mysql.h', 'mysqld_error.h', 'errmsg.h' ],
   LIBS => ($opt->{'embedded'} ? $opt->{'embedded'} : $opt->{libs}),
-  $Devel::CheckLib::VERSION >= 1.07 ? (
-    ccflags => $opt->{cflags} . (
-      # NOTE: Windows version of mysql.h cannot be compiled without SOCKET type (which is unsigned integer of pointer size)
-      ($^O eq 'MSWin32') ? ' -DSOCKET="unsigned long int"' : ''
-    ),
-    $opt->{ldflags} ? (ldflags => $opt->{ldflags}) : (),
-  ) : (
-    # NOTE: Devel::CheckLib prior to 1.07 does not support passing cflags and ldflags
-    #       We just pass incpaths prefixed by -I via INC
-    INC => join(" ", grep /^-I/, split / /, $opt->{cflags}),
-  ),
 );
 
 print "Looks good.\n\n";


### PR DESCRIPTION
Problems with missing header files or cflags are already detected at compile time.