### PR TITLE
Run AppVeyor tests with different perl versions and platforms

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,14 +2,23 @@ version: 1.0.{build}
 
 environment:
   matrix:
-    - perl: "5.20.1.1"
+    - perl: "5.14.4.1"
+    - perl: "5.16.3.20170202"
+    - perl: "5.18.4.1"
+    - perl: "5.20.3.3"
+    - perl: "5.22.3.1"
     - perl: "5.24.1.1"
+
+platform:
+  - x86
+  - x64
 
 services:
   - mysql
 
 install:
-  - cinst StrawberryPerl --version %perl% --allow-empty-checksums
+  - if /I %PLATFORM% == x86 (set x86=--forcex86) else (set "x86= ")
+  - cinst StrawberryPerl --version %perl% %x86% --allow-empty-checksums
   - path C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
   - mkdir %APPVEYOR_BUILD_FOLDER%\tmp
   - set TMPDIR=%APPVEYOR_BUILD_FOLDER%\tmp

--- a/t/87async.t
+++ b/t/87async.t
@@ -46,7 +46,7 @@ $rows = $dbh->do('INSERT INTO async_test VALUES (SLEEP(2), 0, 0)');
 $end = Time::HiRes::gettimeofday();
 
 is $rows, 1;
-ok(($end - $start) >= 2);
+cmp_ok(($end - $start), '>=', 2);
 
 $start = Time::HiRes::gettimeofday();
 $rows = $dbh->do('INSERT INTO async_test VALUES (SLEEP(2), 0, 0)', { async => 1 });
@@ -56,11 +56,11 @@ $end = Time::HiRes::gettimeofday();
 ok $rows;
 is $rows, '0E0';
 
-ok(($end - $start) < 2);
+cmp_ok(($end - $start), '<', 2);
 
 sleep 1 until $dbh->mysql_async_ready;
 $end = Time::HiRes::gettimeofday();
-ok(($end - $start) >= 2);
+cmp_ok(($end - $start), '>=', 2);
 
 $rows = $dbh->mysql_async_result;
 ok !defined($dbh->mysql_async_ready);
@@ -80,11 +80,11 @@ $end = Time::HiRes::gettimeofday();
 ok $rows;
 is $rows, '0E0';
 
-ok(($end - $start) < 2);
+cmp_ok(($end - $start), '<', 2);
 
 sleep 1 until $dbh->mysql_async_ready;
 $end = Time::HiRes::gettimeofday();
-ok(($end - $start) >= 2);
+cmp_ok(($end - $start), '>=', 2);
 
 $rows = $dbh->mysql_async_result;
 
@@ -101,7 +101,7 @@ ok !defined($sth->mysql_async_ready);
 $start = Time::HiRes::gettimeofday();
 ok $sth->execute;
 $end = Time::HiRes::gettimeofday();
-ok(($end - $start) >= 2);
+cmp_ok(($end - $start), '>=', 2);
 
 $sth = $dbh->prepare('SELECT SLEEP(2)', { async => 1 });
 ok !defined($sth->mysql_async_ready);
@@ -109,7 +109,7 @@ $start = Time::HiRes::gettimeofday();
 ok $sth->execute;
 ok defined($sth->mysql_async_ready);
 $end = Time::HiRes::gettimeofday();
-ok(($end - $start) < 2);
+cmp_ok(($end - $start), '<', 2);
 
 sleep 1 until $sth->mysql_async_ready;
 
@@ -117,7 +117,7 @@ my $row = $sth->fetch;
 $end = Time::HiRes::gettimeofday();
 ok $row;
 is $row->[0], 0;
-ok(($end - $start) >= 2);
+cmp_ok(($end - $start), '>=', 2);
 
 $rows = $dbh->do('INSERT INTO async_test VALUES(SLEEP(2), ?, ?', { async => 1 }, 1, 2);
 
@@ -133,13 +133,13 @@ $sth = $dbh->prepare('INSERT INTO async_test VALUES(SLEEP(2), ?, ?)', { async =>
 $start = Time::HiRes::gettimeofday();
 $rows = $sth->execute(1, 2);
 $end = Time::HiRes::gettimeofday();
-ok(($end - $start) < 2);
+cmp_ok(($end - $start), '<', 2);
 ok $rows;
 is $rows, '0E0';
 
 $rows = $sth->mysql_async_result;
 $end = Time::HiRes::gettimeofday();
-ok(($end - $start) >= 2);
+cmp_ok(($end - $start), '>=', 2);
 is $rows, 1;
 
 ( $a, $b, $c ) = $dbh->selectrow_array('SELECT * FROM async_test');
@@ -156,7 +156,7 @@ $start = Time::HiRes::gettimeofday();
 $dbh->selectrow_array('SELECT SLEEP(2)', { async => 1 });
 $end = Time::HiRes::gettimeofday();
 
-ok(($end - $start) >= 2);
+cmp_ok(($end - $start), '>=', 2);
 ok !defined($dbh->mysql_async_result);
 ok !defined($dbh->mysql_async_ready);
 


### PR DESCRIPTION
Now Chocolatey contains more Perl versions for both 32bit and 64bit
architectures. AppVeyor currently run on 64bit machine (also for 32bit
builds) and just set PLATFORM variable which needs to be correctly
propagated to cinst.