### PR TITLE
Set upper timeout limit in test t/87async.t to 1.9

### DIFF
--- a/t/87async.t
+++ b/t/87async.t
@@ -46,7 +46,7 @@ $rows = $dbh->do('INSERT INTO async_test VALUES (SLEEP(2), 0, 0)');
 $end = Time::HiRes::gettimeofday();
 
 is $rows, 1;
-cmp_ok(($end - $start), '>=', 2);
+cmp_ok(($end - $start), '>=', 1.9);
 
 $start = Time::HiRes::gettimeofday();
 $rows = $dbh->do('INSERT INTO async_test VALUES (SLEEP(2), 0, 0)', { async => 1 });
@@ -60,7 +60,7 @@ cmp_ok(($end - $start), '<', 2);
 
 sleep 1 until $dbh->mysql_async_ready;
 $end = Time::HiRes::gettimeofday();
-cmp_ok(($end - $start), '>=', 2);
+cmp_ok(($end - $start), '>=', 1.9);
 
 $rows = $dbh->mysql_async_result;
 ok !defined($dbh->mysql_async_ready);
@@ -84,7 +84,7 @@ cmp_ok(($end - $start), '<', 2);
 
 sleep 1 until $dbh->mysql_async_ready;
 $end = Time::HiRes::gettimeofday();
-cmp_ok(($end - $start), '>=', 2);
+cmp_ok(($end - $start), '>=', 1.9);
 
 $rows = $dbh->mysql_async_result;
 
@@ -101,7 +101,7 @@ ok !defined($sth->mysql_async_ready);
 $start = Time::HiRes::gettimeofday();
 ok $sth->execute;
 $end = Time::HiRes::gettimeofday();
-cmp_ok(($end - $start), '>=', 2);
+cmp_ok(($end - $start), '>=', 1.9);
 
 $sth = $dbh->prepare('SELECT SLEEP(2)', { async => 1 });
 ok !defined($sth->mysql_async_ready);
@@ -117,7 +117,7 @@ my $row = $sth->fetch;
 $end = Time::HiRes::gettimeofday();
 ok $row;
 is $row->[0], 0;
-cmp_ok(($end - $start), '>=', 2);
+cmp_ok(($end - $start), '>=', 1.9);
 
 $rows = $dbh->do('INSERT INTO async_test VALUES(SLEEP(2), ?, ?', { async => 1 }, 1, 2);
 
@@ -139,7 +139,7 @@ is $rows, '0E0';
 
 $rows = $sth->mysql_async_result;
 $end = Time::HiRes::gettimeofday();
-cmp_ok(($end - $start), '>=', 2);
+cmp_ok(($end - $start), '>=', 1.9);
 is $rows, 1;
 
 ( $a, $b, $c ) = $dbh->selectrow_array('SELECT * FROM async_test');
@@ -156,7 +156,7 @@ $start = Time::HiRes::gettimeofday();
 $dbh->selectrow_array('SELECT SLEEP(2)', { async => 1 });
 $end = Time::HiRes::gettimeofday();
 
-cmp_ok(($end - $start), '>=', 2);
+cmp_ok(($end - $start), '>=', 1.9);
 ok !defined($dbh->mysql_async_result);
 ok !defined($dbh->mysql_async_ready);
 


### PR DESCRIPTION
AppVeyor machine seems not to be accure and SLEEP(2) sometimes takes only 1.998s.