### PR TITLE
Bail out tests when env CONNECTION_TESTING is 1 and connection to MySQL server is not possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,7 @@ install:
       chmod +x "$SANDBOX_HOME/msb/mysql_config" || exit 1 ;
     fi
   - export RELEASE_TESTING=1
+  - export CONNECTION_TESTING=1
 script:
   - if [ -n "$DB" ]; then
       perl Makefile.PL --mysql_config="$SANDBOX_HOME/msb/mysql_config" --testuser=msandbox --testpassword=msandbox --testhost=127.0.0.1 --testport=3310 && make disttest || exit 1;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,4 +31,5 @@ build_script:
   - perl Makefile.PL --mysql_config=c:\strawberry\c\bin\mysql_config.bat --testuser=root --testpassword=Password12!
 
 test_script:
+  - set CONNECTION_TESTING=1
   - dmake test

--- a/t/05dbcreate.t
+++ b/t/05dbcreate.t
@@ -12,19 +12,18 @@ require 'lib.pl';
 # remove database from DSN
 $test_dsn =~ s/^DBI:mysql:([^:;]+)([:;]?)/DBI:mysql:$2/;
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    diag $@;
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 plan tests => 2;
 
 ok defined $dbh, "Connected to database";
 eval{ $dbh->do("CREATE DATABASE IF NOT EXISTS $test_db") };
 if($@) {
-    diag "No permission to '$test_db' database on '$test_dsn' for user '$test_user'";
+    if ( $ENV{CONNECTION_TESTING} ) {
+        BAIL_OUT "No permission to '$test_db' database on '$test_dsn' for user '$test_user': $@";
+    } else {
+        diag "No permission to '$test_db' database on '$test_dsn' for user '$test_user': $@";
+    }
 } else {
     diag "Database '$test_db' accessible";
 }

--- a/t/10connect.t
+++ b/t/10connect.t
@@ -10,14 +10,8 @@ use vars qw($test_dsn $test_user $test_password $test_db);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-
-if ($@) {
-  diag $@;
-  plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
 ok(defined $dbh, "Connected to database");
 

--- a/t/15reconnect.t
+++ b/t/15reconnect.t
@@ -11,12 +11,11 @@ require 'lib.pl';
 
 my $dbh;
 my $sth;
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1})};
 
-if ($@) {
-  plan skip_all => "no database connection";
-}
+$dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
+$dbh->disconnect();
+
 plan tests => 13 * 2;
 
 for my $mysql_server_prepare (0, 1) {

--- a/t/16dbi-get_info.t
+++ b/t/16dbi-get_info.t
@@ -10,13 +10,8 @@ use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1})};
-
-if ($@) {
-  plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
 # DBI documentation states:
 # Because some DBI methods make use of get_info(), drivers are strongly

--- a/t/20createdrop.t
+++ b/t/20createdrop.t
@@ -9,13 +9,9 @@ use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
-if ($@) {
-    plan skip_all => "no database connection";
-}
 plan tests => 4;
 
 ok(defined $dbh, "Connected to database");

--- a/t/25lockunlock.t
+++ b/t/25lockunlock.t
@@ -8,13 +8,8 @@ require 'lib.pl';
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
 plan tests => 13;
 

--- a/t/29warnings.t
+++ b/t/29warnings.t
@@ -9,13 +9,8 @@ $|= 1;
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0});};
-
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0});
 
 if ($dbh->{mysql_serverversion} < 40101) {
     plan skip_all => "Servers < 4.1.1 do not report warnings";

--- a/t/30insertfetch.t
+++ b/t/30insertfetch.t
@@ -10,13 +10,8 @@ $|= 1;
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all =>
-        "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
 ok(defined $dbh, "Connected to database");
 

--- a/t/31insertid.t
+++ b/t/31insertid.t
@@ -8,14 +8,9 @@ use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
 require "lib.pl";
 
-my $dbh;
-eval{$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-			    {RaiseError => 1});};
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+			    {RaiseError => 1});
 
-if ($@) {
-    plan skip_all =>
-        "no database connection";
-}
 plan tests => 19;
 
 SKIP: {

--- a/t/32insert_error.t
+++ b/t/32insert_error.t
@@ -8,13 +8,9 @@ require 'lib.pl';
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1})};
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
-if ($@) {
-    plan skip_all => "no database connection";
-}
 plan tests => 9;
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t32");

--- a/t/35limit.t
+++ b/t/35limit.t
@@ -13,12 +13,8 @@ use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 plan tests => 111;
 
 ok(defined $dbh, "Connected to database");

--- a/t/35prepare.t
+++ b/t/35prepare.t
@@ -10,13 +10,9 @@ my ($row, $sth, $dbh);
 my ($def, $rows, $errstr, $ret_ref);
 use vars qw($test_dsn $test_user $test_password);
 
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-    { RaiseError => 1, AutoCommit => 1});};
+$dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+    { RaiseError => 1, AutoCommit => 1});
 
-if ($@) {
-    plan skip_all =>
-        "no database connection";
-}
 plan tests => 49;
 
 ok(defined $dbh, "Connected to database");

--- a/t/40bindparam.t
+++ b/t/40bindparam.t
@@ -7,12 +7,8 @@ use lib 't', '.';
 require 'lib.pl';
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 1 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 1 });
 
 if (!MinimumVersion($dbh, '4.1')) {
     plan skip_all =>

--- a/t/40bindparam2.t
+++ b/t/40bindparam2.t
@@ -7,13 +7,9 @@ use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1}) or ServerError();};
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
-if ($@) {
-    plan skip_all => "no database connection";
-}
 plan tests => 13;
 
 SKIP: {

--- a/t/40bit.t
+++ b/t/40bit.t
@@ -10,15 +10,10 @@ require 'lib.pl';
 sub VerifyBit ($) {
 }
 
-my $dbh;
 my $charset= 'DEFAULT CHARSET=utf8';
 
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1}) or ServerError() ;};
-
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
 if ($dbh->{mysql_serverversion} < 50008) {
     plan skip_all => "Servers < 5.0.8 do not support b'' syntax";

--- a/t/40blobs.t
+++ b/t/40blobs.t
@@ -21,18 +21,12 @@ sub ShowBlob($) {
     }
 }
 
-my $dbh;
 my $charset= 'DEFAULT CHARSET=utf8';
 
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1}) or ServerError() ;};
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
-if ($@) {
-    plan skip_all => "no database connection";
-}
-else {
-    plan tests => 14;
-}
+plan tests => 14;
 
 if (!MinimumVersion($dbh, '4.1')) {
     $charset= '';

--- a/t/40catalog.t
+++ b/t/40catalog.t
@@ -9,16 +9,12 @@ $|= 1;
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError            => 1,
                         PrintError            => 1,
                         AutoCommit            => 1,
-                        mysql_server_prepare  => 0 });};
+                        mysql_server_prepare  => 0 });
 
-if ($@) {
-    plan skip_all => "no database connection";
-}
 plan tests => 78;
 
 ok(defined $dbh, "connecting");

--- a/t/40keyinfo.t
+++ b/t/40keyinfo.t
@@ -8,13 +8,9 @@ require 'lib.pl';
 $|= 1;
 
 use vars qw($test_dsn $test_user $test_password);
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
-if ($@) {
-    plan skip_all => "no database connection";
-}
 plan tests => 7;
 
 $dbh->{mysql_server_prepare}= 0;

--- a/t/40listfields.t
+++ b/t/40listfields.t
@@ -12,13 +12,9 @@ my $quoted;
 
 my $create;
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
-if ($@) {
-    plan skip_all => "no database connection";
-}
 plan tests => 25;
 
 $dbh->{mysql_server_prepare}= 0;

--- a/t/40nulls.t
+++ b/t/40nulls.t
@@ -8,12 +8,8 @@ use lib 't', '.';
 require 'lib.pl';
 
 my ($dbh, $sth);
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all =>
-        "no database connection";
-}
+$dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 plan tests => 10;
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t40nulls"), "DROP TABLE IF EXISTS dbd_mysql_t40nulls";

--- a/t/40nulls_prepare.t
+++ b/t/40nulls_prepare.t
@@ -10,12 +10,8 @@ my ($row, $sth, $dbh);
 my ($table, $def, $rows, $errstr, $ret_ref);
 use vars qw($table $test_dsn $test_user $test_password);
 
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-    { RaiseError => 1, AutoCommit => 1});};
-
-if ($@) {
-    plan skip_all => "no database connection",
-}
+$dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+    { RaiseError => 1, AutoCommit => 1});
 
 ok(defined $dbh, "Connected to database");
 

--- a/t/40numrows.t
+++ b/t/40numrows.t
@@ -8,11 +8,8 @@ use lib 't', '.';
 require 'lib.pl';
 
 my ($dbh, $sth, $aref);
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+$dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 plan tests => 30;
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t40numrows");

--- a/t/40server_prepare.t
+++ b/t/40server_prepare.t
@@ -11,13 +11,8 @@ $|= 1;
 
 $test_dsn.= ";mysql_server_prepare=1;mysql_server_prepare_disable_fallback=1";
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
 if ($dbh->{mysql_clientversion} < 40103 or $dbh->{mysql_serverversion} < 40103) {
     plan skip_all => "You must have MySQL version 4.1.3 and greater for this test to run";

--- a/t/40server_prepare_crash.t
+++ b/t/40server_prepare_crash.t
@@ -7,8 +7,7 @@ use DBI;
 use vars qw($test_dsn $test_user $test_password);
 require "t/lib.pl";
 
-my $dbh = eval { DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 1, AutoCommit => 0, mysql_server_prepare => 1, mysql_server_prepare_disable_fallback => 1 }) };
-plan skip_all => "no database connection" if $@ or not $dbh;
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 1, AutoCommit => 0, mysql_server_prepare => 1, mysql_server_prepare_disable_fallback => 1 });
 plan skip_all => "You must have MySQL version 4.1.3 and greater for this test to run" if $dbh->{mysql_clientversion} < 40103 or $dbh->{mysql_serverversion} < 40103;
 
 plan tests => 39;

--- a/t/40server_prepare_error.t
+++ b/t/40server_prepare_error.t
@@ -9,13 +9,8 @@ require 'lib.pl';
 use vars qw($test_dsn $test_user $test_password);
 
 $test_dsn.= ";mysql_server_prepare=1;mysql_server_prepare_disable_fallback=1";
-my $dbh;
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1})};
-
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
 if ($dbh->{mysql_clientversion} < 40103 or $dbh->{mysql_serverversion} < 40103) {
     plan skip_all =>

--- a/t/40types.t
+++ b/t/40types.t
@@ -11,13 +11,8 @@ $|= 1;
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all =>
-        "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 plan tests => 40;
 
 ok(defined $dbh, "Connected to database");

--- a/t/41bindparam.t
+++ b/t/41bindparam.t
@@ -9,12 +9,8 @@ use lib 't', '.';
 require 'lib.pl';
 
 my ($dbh, $sth);
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all =>
-        "no database connection";
-}
+$dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 plan tests => 11;
 
 my ($rows, $errstr, $ret_ref);

--- a/t/41blobs_prepare.t
+++ b/t/41blobs_prepare.t
@@ -9,13 +9,9 @@ use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1})};
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
-if ($@) {
-  plan skip_all => "no database connection";
-}
 plan tests => 25;
 
 my @chars = grep !/[0O1Iil]/, 0..9, 'A'..'Z', 'a'..'z';

--- a/t/41int_min_max.t
+++ b/t/41int_min_max.t
@@ -9,12 +9,8 @@ use Data::Dumper;
 require 'lib.pl';
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 1 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 1 });
 
 if ($dbh->{mysql_serverversion} < 50002) {
     plan skip_all =>

--- a/t/42bindparam.t
+++ b/t/42bindparam.t
@@ -7,12 +7,8 @@ use DBI;
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
 plan tests => 12;
 

--- a/t/43count_params.t
+++ b/t/43count_params.t
@@ -7,12 +7,8 @@ use lib 't', '.';
 require 'lib.pl';
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 if (!MinimumVersion($dbh, '4.1') ) {
     plan skip_all =>
         "SKIP TEST: You must have MySQL version 4.1 and greater for this test to run";

--- a/t/50chopblanks.t
+++ b/t/50chopblanks.t
@@ -8,20 +8,18 @@ require 'lib.pl';
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 1 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 1 });
 if ($dbh->{mysql_serverversion} < 40103) {
     plan skip_all => "You must have MySQL version 4.1.3 and greater for this test to run";
 }
+$dbh->disconnect;
+
 plan tests => 36 * 2;
 
 for my $mysql_server_prepare (0, 1) {
-eval {$dbh= DBI->connect("$test_dsn;mysql_server_prepare=$mysql_server_prepare;mysql_server_prepare_disable_fallback=1", $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 1 });};
+$dbh = DBI->connect("$test_dsn;mysql_server_prepare=$mysql_server_prepare;mysql_server_prepare_disable_fallback=1", $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 1 });
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t50chopblanks"), "drop table if exists dbd_mysql_t50chopblanks";
 

--- a/t/50commit.t
+++ b/t/50commit.t
@@ -8,12 +8,8 @@ require 'lib.pl';
 
 use vars qw($have_transactions $got_warning $test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
 sub catch_warning ($) {
     $got_warning = 1;

--- a/t/51bind_type_guessing.t
+++ b/t/51bind_type_guessing.t
@@ -9,12 +9,8 @@ require 'lib.pl';
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 plan tests => 26; 
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t51bind_type_guessing"), "drop table if exists dbd_mysql_t51bind_type_guessing";

--- a/t/52comment.t
+++ b/t/52comment.t
@@ -9,17 +9,11 @@ require 'lib.pl';
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval { $dbh= DBI->connect($test_dsn, $test_user, $test_password,
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1,
                         PrintError => 1, 
                         AutoCommit => 0, }
                         );
-     };
-if ($@) {
-    plan skip_all => 
-    plan skip_all => "no database connection";
-}
 plan tests => 30; 
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t52comment"), "drop table if exists dbd_mysql_t52comment";

--- a/t/53comment.t
+++ b/t/53comment.t
@@ -9,18 +9,12 @@ require 'lib.pl';
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval { $dbh= DBI->connect($test_dsn, $test_user, $test_password,
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1,
                         PrintError => 1, 
                         AutoCommit => 0,
                         mysql_bind_comment_placeholders => 1,}
                         );
-     };
-if ($@) {
-    plan skip_all => 
-        "no database connection";
-}
 
 my $create= <<"EOTABLE";
 CREATE TEMPORARY TABLE dbd_mysql_53 (

--- a/t/55utf8.t
+++ b/t/55utf8.t
@@ -8,12 +8,8 @@ use vars qw($COL_NULLABLE $COL_KEY);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
 #
 # DROP/CREATE PROCEDURE will give syntax error for these versions

--- a/t/55utf8mb4.t
+++ b/t/55utf8mb4.t
@@ -7,12 +7,8 @@ use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
 eval {
    $dbh->{PrintError} = 0;

--- a/t/56connattr.t
+++ b/t/56connattr.t
@@ -11,18 +11,13 @@ require 'lib.pl';
 
 use vars qw($test_dsn $test_user $test_password $table);
 
-my $dbh;
-eval { $dbh= DBI->connect($test_dsn, $test_user, $test_password,
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1,
                         PrintError => 0,
                         AutoCommit => 0,
                         mysql_conn_attrs => { foo => 'bar' },
                         }
                         );
-     };
-if ($@) {
-    plan skip_all => "no database connection";
-}
 
 my @pfenabled = $dbh->selectrow_array("show variables like 'performance_schema'");
 if (!@pfenabled) {

--- a/t/60leaks.t
+++ b/t/60leaks.t
@@ -26,12 +26,8 @@ eval { require Storable };
 $have_storable = $@ ? 0 : 1;
 
 my ($dbh, $sth);
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                                            { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-        plan skip_all =>
-                "no database connection";
-}
+$dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                                            { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 $dbh->disconnect;
 plan tests => 27 * 2;
 
@@ -51,7 +47,7 @@ for my $mysql_server_prepare (0, 1) {
 
 note "Testing memory leaks with mysql_server_prepare=$mysql_server_prepare\n";
 
-$dbh= DBI->connect($test_dsn, $test_user, $test_password,
+$dbh= DbiTestConnect($test_dsn, $test_user, $test_password,
                    { RaiseError => 1, PrintError => 1, AutoCommit => 0, mysql_server_prepare => $mysql_server_prepare, mysql_server_prepare_disable_fallback => 1 });
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t60leaks");
@@ -74,16 +70,12 @@ $not_ok = 0;
 $prev_size= undef;
 
 for (my $i = 0;    $i < $COUNT_CONNECT;    $i++) {
-    eval {$dbh2 = DBI->connect($test_dsn, $test_user, $test_password,
+    $dbh2 = DBI->connect($test_dsn, $test_user, $test_password,
                                { RaiseError => 1, 
                                  PrintError => 1,
                                  AutoCommit => 0,
                                  mysql_server_prepare => $mysql_server_prepare,
-                               });};
-    if ($@) {
-        $not_ok++;
-        last;
-    }
+                               });
 
     if ($i % 100    ==    99) {
         $size = size();

--- a/t/65segfault.t
+++ b/t/65segfault.t
@@ -10,26 +10,15 @@ $|= 1;
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       {
                           mysql_auto_reconnect  => 1,
                           RaiseError => 1,
                           PrintError => 1,
                           AutoCommit => 1 });
-};
 
-if ($@) {
-    plan skip_all =>
-        "no database connection";
-}
-my $dbh2;
-eval {$dbh2= DBI->connect($test_dsn, $test_user, $test_password);};
+my $dbh2= DbiTestConnect($test_dsn, $test_user, $test_password);
 
-if ($@) {
-    plan skip_all =>
-        "no database connection";
-}
 plan tests => 5;
 
 ok(defined $dbh, "Handle 1 Connected to database");

--- a/t/65types.t
+++ b/t/65types.t
@@ -7,12 +7,8 @@ use DBI;
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 plan tests => 19;
 
 ok $dbh->do("drop table if exists dbd_mysql_65types");

--- a/t/70takeimp.t
+++ b/t/70takeimp.t
@@ -8,20 +8,13 @@ require 'lib.pl';
 $|= 1;
 use vars qw($test_dsn $test_user $test_password);
 
-my $drh;
-eval {$drh = DBI->install_driver('mysql')};
-
-if ($@) {
+my $drh = eval { DBI->install_driver('mysql') } or do {
     plan skip_all => "Can't obtain driver handle ERROR: $@. Can't continue test";
-}
+};
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 })};
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
-if ($@) {
-    plan skip_all => "no database connection";
-}
 unless ($DBI::VERSION ge '1.607') {
     plan skip_all => "version of DBI $DBI::VERSION doesn't support this test. Can't continue test";
 }

--- a/t/71impdata.t
+++ b/t/71impdata.t
@@ -12,13 +12,8 @@ $| = 1;
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1})};
-
-if ($@) {
-  plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
 my $drh    = $dbh->{Driver};
 if (! defined $drh) {

--- a/t/75supported_sql.t
+++ b/t/75supported_sql.t
@@ -9,13 +9,9 @@ require 'lib.pl';
 
 my ($row, $vers, $test_procs);
 
-my $dbh;
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1})};
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
-if ($@) {
-  plan skip_all => "no database connection";
-}
 plan tests => 12;
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t75supported");

--- a/t/76multi_statement.t
+++ b/t/76multi_statement.t
@@ -9,26 +9,23 @@ $|= 1;
 
 use vars qw($test_dsn $test_user $test_password);
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 1, AutoCommit => 0,
-                        mysql_multi_statements => 1 });};
+                        mysql_multi_statements => 1 });
 
-if ($@) {
-    plan skip_all => "no database connection";
+if ($dbh->{mysql_clientversion} < 40101 or $dbh->{mysql_serverversion} < 40101) {
+  plan skip_all => "Server doesn't support multi statements";
 }
+
+if ($dbh->{mysql_clientversion} < 50025 or ($dbh->{mysql_serverversion} >= 50100 and $dbh->{mysql_serverversion} < 50112)) {
+  plan skip_all => "Server has deadlock bug 16581";
+}
+
 plan tests => 26;
 
 ok (defined $dbh, "Connected to database with multi statement support");
 
 $dbh->{mysql_server_prepare}= 0;
-
-SKIP: {
-  skip "Server doesn't support multi statements", 25
-  if $dbh->{mysql_clientversion} < 40101 or $dbh->{mysql_serverversion} < 40101;
-
-  skip "Server has deadlock bug 16581", 25
-  if $dbh->{mysql_clientversion} < 50025 or ($dbh->{mysql_serverversion} >= 50100 and $dbh->{mysql_serverversion} < 50112);
 
   ok($dbh->do("SET SQL_MODE=''"),"init connection SQL_MODE non strict");
 
@@ -72,6 +69,5 @@ SKIP: {
   ok(!$sth->more_results());
   ok($sth->err(), "Err was set after more_results");
   ok $dbh->do("DROP TABLE dbd_mysql_t76multi");
-};
 
 $dbh->disconnect();

--- a/t/80procs.t
+++ b/t/80procs.t
@@ -8,13 +8,8 @@ use Test::More;
 use vars qw($test_dsn $test_user $test_password);
 
 my ($row, $vers, $test_procs, $dbh, $sth);
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1})};
-
-if ($@) {
-    plan skip_all =>
-        "no database connection";
-}
+$dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
 #
 # DROP/CREATE PROCEDURE will give syntax error

--- a/t/81procs.t
+++ b/t/81procs.t
@@ -8,13 +8,8 @@ use Test::More;
 use vars qw($test_dsn $test_user $test_password);
 
 my ($row, $vers, $test_procs, $dbh, $sth);
-eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1})};
-
-if ($@) {
-    plan skip_all =>
-        "no database connection";
-}
+$dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
 #
 # DROP/CREATE PROCEDURE will give syntax error

--- a/t/85init_command.t
+++ b/t/85init_command.t
@@ -10,16 +10,12 @@ use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
         {   RaiseError => 1,
             PrintError => 1,
             AutoCommit => 0,
-            mysql_init_command => 'SET SESSION wait_timeout=7' });};
+            mysql_init_command => 'SET SESSION wait_timeout=7' });
 
-if ($@) {
-    plan skip_all => "no database connection";
-}
 plan tests => 5;
 
 ok(defined $dbh, "Connected to database");

--- a/t/86_bug_36972.t
+++ b/t/86_bug_36972.t
@@ -9,12 +9,8 @@ use vars qw($test_dsn $test_user $test_password);
 
 $|= 1;
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 0, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
 plan tests => 11;
 
 ok(defined $dbh, "connecting");

--- a/t/87async.t
+++ b/t/87async.t
@@ -11,12 +11,8 @@ use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 0, PrintError => 0, AutoCommit => 0 });};
-if (!$dbh) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 0, PrintError => 0, AutoCommit => 0 });
 if ($dbh->{mysql_serverversion} < 50012) {
     plan skip_all => "Servers < 5.0.12 do not support SLEEP()";
 }

--- a/t/88async-multi-stmts.t
+++ b/t/88async-multi-stmts.t
@@ -9,12 +9,8 @@ use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 0, PrintError => 0, AutoCommit => 0 });};
-if (!$dbh) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 0, PrintError => 0, AutoCommit => 0 });
 plan tests => 8;
 
 $dbh->do(<<SQL);

--- a/t/89async-method-check.t
+++ b/t/89async-method-check.t
@@ -75,12 +75,8 @@ my %sth_args = (
     bind_columns      => [\(my $scalar3)],
 );
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 0, PrintError => 0, AutoCommit => 0 });};
-if (!$dbh) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 0, PrintError => 0, AutoCommit => 0 });
 plan tests =>
   2 * @db_safe_methods     +
   4 * @db_unsafe_methods   +

--- a/t/90utf8_params.t
+++ b/t/90utf8_params.t
@@ -15,8 +15,7 @@ use vars qw($COL_NULLABLE $COL_KEY);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh = eval { DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1 }) } or
-    plan skip_all => "no database connection";
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1 });
 
 if ($dbh->{mysql_serverversion} < 50000) {
     plan skip_all => "You must have MySQL version 5.0 and greater for this test to run";

--- a/t/91errcheck.t
+++ b/t/91errcheck.t
@@ -8,12 +8,8 @@ use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 0, PrintError => 0, AutoCommit => 0 });};
-if (!$dbh) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 0, PrintError => 0, AutoCommit => 0 });
 
 plan tests => 1;
 

--- a/t/99_bug_server_prepare_blob_null.t
+++ b/t/99_bug_server_prepare_blob_null.t
@@ -8,13 +8,9 @@ use vars qw($COL_NULLABLE $COL_KEY);
 use lib 't', '.';
 require 'lib.pl';
 
-my $dbh;
 $test_dsn .= ';mysql_server_prepare=1;mysql_server_prepare_disable_fallback=1';
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
 #
 # DROP/CREATE PROCEDURE will give syntax error for these versions

--- a/t/lib.pl
+++ b/t/lib.pl
@@ -53,6 +53,29 @@ if (-f ($file = "t/$mdriver.mtest")  ||
     }
 }
 
+sub DbiTestConnect {
+    return (eval { DBI->connect(@_) } or do {
+        my $err;
+        if ( $@ ) {
+            $err = $@;
+            $err =~ s/ at \S+ line \d+\s*$//;
+        }
+        if ( not $err ) {
+            $err = $DBI::errstr;
+            $err = "unknown error" unless $err;
+            my $user = $_[1];
+            my $dsn = $_[0];
+            $dsn =~ s/^DBI:mysql://;
+            $err = "DBI connect('$dsn','$user',...) failed: $err";
+        }
+        if ( $ENV{CONNECTION_TESTING} ) {
+            BAIL_OUT "no database connection: $err";
+        } else {
+            plan skip_all => "no database connection: $err";
+        }
+    });
+}
+
 
 #
 #   Print a DBI error message

--- a/t/magic.t
+++ b/t/magic.t
@@ -11,8 +11,7 @@ my $tb = Test::More->builder;
 binmode $tb->failure_output, ":utf8";
 binmode $tb->todo_output,    ":utf8";
 
-my $dbh = eval { DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 0, mysql_server_prepare_disable_fallback => 1 }) };
-plan skip_all => "no database connection" if $@ or not $dbh;
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 0, mysql_server_prepare_disable_fallback => 1 });
 
 plan tests => 288*2;
 

--- a/t/rt110983-valid-mysqlfd.t
+++ b/t/rt110983-valid-mysqlfd.t
@@ -7,8 +7,7 @@ use DBI;
 use vars qw($test_dsn $test_user $test_password);
 require "t/lib.pl";
 
-my $dbh = eval { DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 0 }) };
-plan skip_all => "no database connection" if $@ or not $dbh;
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 0 });
 
 plan tests => 4;
 

--- a/t/rt118977-zerofill.t
+++ b/t/rt118977-zerofill.t
@@ -7,8 +7,7 @@ use DBI;
 use vars qw($test_dsn $test_user $test_password);
 require "t/lib.pl";
 
-my $dbh = eval { DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 1 }) };
-plan skip_all => "no database connection" if $@ or not $dbh;
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 1 });
 
 plan tests => 4*2;
 

--- a/t/rt25389-bin-case.t
+++ b/t/rt25389-bin-case.t
@@ -8,12 +8,8 @@ require "t/lib.pl";
 
 use Test::More;
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 0, AutoCommit => 1 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 0, AutoCommit => 1 });
 
 if (!MinimumVersion($dbh, '5.1')) {
     plan skip_all =>

--- a/t/rt50304-column_info_parentheses.t
+++ b/t/rt50304-column_info_parentheses.t
@@ -8,12 +8,8 @@ require "t/lib.pl";
 
 use Test::More;
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 0, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
 
 ok($dbh->do("DROP TABLE IF EXISTS dbd_mysql_rt50304_column_info"));
 

--- a/t/rt61849-bind-param-buffer-overflow.t
+++ b/t/rt61849-bind-param-buffer-overflow.t
@@ -9,8 +9,7 @@ require "t/lib.pl";
 
 my $INSECURE_VALUE_FROM_USER = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 
-my $dbh = eval { DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 1, AutoCommit => 0 }) };
-plan skip_all => "no database connection" if $@ or not $dbh;
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 1, AutoCommit => 0 });
 
 plan tests => 2;
 my $sth = $dbh->prepare("select * from unknown_table where id=?");

--- a/t/rt75353-innodb-lock-timeout.t
+++ b/t/rt75353-innodb-lock-timeout.t
@@ -7,11 +7,9 @@ use DBI;
 use vars qw($test_dsn $test_user $test_password);
 require "t/lib.pl";
 
-my $dbh1 = eval { DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 0 }) };
-plan skip_all => "no database connection" if $@ or not $dbh1;
+my $dbh1 = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 0 });
 
-my $dbh2 = eval { DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 0 }) };
-plan skip_all => "no database connection" if $@ or not $dbh2;
+my $dbh2 = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 0 });
 
 my @ilwtenabled = $dbh1->selectrow_array("SHOW VARIABLES LIKE 'innodb_lock_wait_timeout'");
 if (!@ilwtenabled) {

--- a/t/rt83494-quotes-comments.t
+++ b/t/rt83494-quotes-comments.t
@@ -11,12 +11,8 @@ use Test::More;
 use vars qw($test_dsn $test_user $test_password $state);
 require "t/lib.pl";
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 0, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
 
 my %tests = (
   questionmark => " -- Does the question mark at the end confuse DBI::MySQL?\nselect ?",

--- a/t/rt85919-fetch-lost-connection.t
+++ b/t/rt85919-fetch-lost-connection.t
@@ -6,12 +6,8 @@ use lib 't', '.';
 use vars qw($test_dsn $test_user $test_password $mdriver);
 require 'lib.pl';
 
-my $dbh;
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 0, AutoCommit => 0 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
 my $sth;
 my $ok = eval {
     note "Connecting...\n";

--- a/t/rt88006-bit-prepare.t
+++ b/t/rt88006-bit-prepare.t
@@ -14,8 +14,8 @@ my $sth;
 
 my $dsn = $test_dsn;
 $dsn .= ';mysql_server_prepare=1;mysql_server_prepare_disable_fallback=1' if $scenario eq 'prepare';
-eval {$dbh = DBI->connect($dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1})};
+$dbh = DbiTestConnect($dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
 if ($@) {
   plan skip_all => "no database connection";

--- a/t/rt91715.t
+++ b/t/rt91715.t
@@ -10,15 +10,11 @@ $|= 1;
 use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
 require 'lib.pl';
-my $dbh;
 
 # yes, we will reconnect, but I want to keep the "fail if not connect"
 # separate from the actual test where we reconnect
-eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
-                      { RaiseError => 1, PrintError => 1, AutoCommit => 1 });};
-if ($@) {
-    plan skip_all => "no database connection";
-}
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 1 });
 plan tests => 6;
 
 for my $ur (0,1) {


### PR DESCRIPTION
On AppVeyor and Travis CI is non-working MySQL or MariaDB server fatal
error which should not be ignored. This patch introduce new test function
DbiTestConnect() which is wrapper around DBI->connect() and based on env
CONNECTION_TESTING value either skip test or bail out. All tests are now
adjusted to use DbiTestConnect() on startup.