### PR TITLE
Fix decoding UTF-8 database, table and column names and warning and error messages

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -54,6 +54,7 @@ t/52comment.t
 t/53comment.t
 t/55utf8.t
 t/55utf8mb4.t
+t/55utf8_jp.t
 t/56connattr.t
 t/60leaks.t
 t/65segfault.t

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -27,20 +27,6 @@
       return (value);\
   }
 
-#ifndef PERL_STATIC_INLINE
-#define PERL_STATIC_INLINE static
-#endif
-
-#if MYSQL_VERSION_ID >= FIELD_CHARSETNR_VERSION
-PERL_STATIC_INLINE bool charsetnr_is_utf8(unsigned int id)
-{
-  /* See mysql source code for all utf8 ids: grep -E '^(CHARSET_INFO|struct charset_info_st).*utf8' -A 2 -r strings | grep number | sed -E 's/^.*-  *([^,]+),.*$/\1/' | sort -n */
-  /* Some utf8 ids (selected at mysql compile time) can be retrieved by: SELECT ID FROM INFORMATION_SCHEMA.COLLATIONS WHERE CHARACTER_SET_NAME LIKE 'utf8%' ORDER BY ID */
-  return (id == 33 || id == 45 || id == 46 || id == 83 || (id >= 192 && id <= 215) || (id >= 223 && id <= 247) || (id >= 254 && id <= 277) || (id >= 576 && id <= 578)
-      || (id >= 608 && id <= 610) || id == 1057 || (id >= 1069 && id <= 1070) || id == 1107 || id == 1216 || id == 1283 || id == 1248 || id == 1270);
-}
-#endif
-
 PERL_STATIC_INLINE bool str_is_nonascii(const char *str, STRLEN len)
 {
   STRLEN i;

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1507,7 +1507,8 @@ See L</"STATEMENT HANDLES">.
 =item mysql_enable_utf8
 
 This attribute affects input data from DBI (statement and bind parameters) and
-output data from the mysql server.
+output data from the MySQL server.  Applies also for database, table and column
+names and also for warning and error messages from MySQL server.
 
 If used as a part of the call to C<connect()> then it issues the command
 C<SET NAMES utf8>.

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -169,17 +169,19 @@ sub connect {
 sub data_sources {
     my($self) = shift;
     my($attributes) = shift;
-    my($host, $port, $user, $password) = ('', '', '', '');
+    my($host, $port, $user, $password, $utf8) = ('', '', '', '');
     if ($attributes) {
       $host = $attributes->{host} || '';
       $port = $attributes->{port} || '';
       $user = $attributes->{user} || '';
       $password = $attributes->{password} || '';
+      $utf8 = $attributes->{utf8} || $attributes->{mysql_enable_utf8};
     }
-    my(@dsn) = $self->func($host, $port, $user, $password, '_ListDBs');
+    my(@dsn) = $self->func($host, $port, $user, $password, $utf8, '_ListDBs');
+    $utf8 = $utf8 ? ";mysql_enable_utf8=1" : "";
     my($i);
     for ($i = 0;  $i < @dsn;  $i++) {
-	$dsn[$i] = "DBI:mysql:$dsn[$i]";
+	$dsn[$i] = "DBI:mysql:$dsn[$i]$utf8";
     }
     @dsn;
 }
@@ -1377,6 +1379,10 @@ running on C<$hostname>, port C<$port>. This is a legacy
 method.  Instead, you should use the portable method
 
     @dbs = DBI->data_sources("mysql");
+
+or with connection arguments
+
+    @dbs = DBI->data_sources("mysql", {"host" => $host, "port" => $port, "user" => $user, "password" => $pass, "utf8" => 1});
 
 =back
 

--- a/t/55utf8_jp.t
+++ b/t/55utf8_jp.t
@@ -1,0 +1,98 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+use Encode;
+
+use vars qw($test_dsn $test_user $test_password);
+require "t/lib.pl";
+
+my $dbh = eval {
+  DBI->connect($test_dsn, $test_user, $test_password, { mysql_enable_utf8 => 1, PrintError => 1, RaiseError => 1 });
+} or do {
+  plan skip_all => "no database connection";
+};
+
+eval { $dbh->do("SET lc_messages = 'ja_JP'") } or do { plan skip_all => "Server lc_messages ja_JP are needed for this test" };
+
+plan tests => 21;
+
+my $jpnTable = "\N{U+8868}"; # Japanese table
+my $jpnGender = "\N{U+6027}\N{U+5225}"; # Japanese word "gender"
+my $jpnYamadaTaro = "\N{U+5c71}\N{U+7530}\N{U+592a}\N{U+90ce}"; # a Japanese person name
+my $jpnMale = "\N{U+7537}"; # Japanese word "male"
+my $jpnErr = qr/\N{U+4ed8}\N{U+8fd1}.*\N{U+884c}\N{U+76ee}/;
+
+my $sth;
+my $row;
+
+ok($dbh->do("
+CREATE TEMPORARY TABLE $jpnTable (
+  name VARCHAR(20),
+  $jpnGender CHAR(1)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
+"));
+
+ok($sth = $dbh->prepare("INSERT INTO $jpnTable (name, $jpnGender) VALUES (?, ?)"));
+ok($sth->execute($jpnYamadaTaro, $jpnMale));
+
+ok($sth = $dbh->prepare("SELECT * FROM $jpnTable"));
+ok($sth->execute());
+ok($row = $sth->fetchrow_hashref());
+
+is($row->{name}, $jpnYamadaTaro);
+is($row->{$jpnGender}, $jpnMale);
+ok(!exists $row->{Encode::encode("UTF-8", $jpnGender)});
+
+is_deeply($sth->{NAME}, [ 'name', $jpnGender ]);
+is_deeply($sth->{mysql_table}, [ $jpnTable, $jpnTable ]);
+
+my $warn;
+my $dieerr;
+my $dbierr;
+my $failed;
+
+$failed = 0;
+$dieerr = undef;
+$dbierr = undef;
+$dbh->{HandleError} = sub { $dbierr = $_[0]; die $_[0]; };
+eval {
+  $sth = $dbh->prepare("foo");
+  $sth->execute();
+  1;
+} or do {
+  $dieerr = $@;
+  $failed = 1;
+};
+$dbh->{HandleError} = undef;
+
+ok($failed);
+like($dieerr, $jpnErr);
+like($dbierr, $jpnErr);
+like($DBI::errstr, $jpnErr);
+like($dbh->errstr, $jpnErr);
+
+$failed = 0;
+$warn = undef;
+$dieerr = undef;
+$SIG{__WARN__} = sub { $warn = $_[0] };
+eval {
+  $sth = $dbh->prepare("foo");
+  $sth->execute();
+  1;
+} or do {
+  $dieerr = $@;
+  $failed = 1;
+};
+$SIG{__WARN__} = 'default';
+
+ok($failed);
+like($DBI::errstr, $jpnErr);
+like($dbh->errstr, $jpnErr);
+
+SKIP : {
+  skip "Perl 5.13.1 and DBI 1.635 are required due to bug RT 102404", 2 unless $] >= 5.013001 and eval "use DBI 1.635; 1;";
+  like($warn, $jpnErr);
+  like($dieerr, $jpnErr);
+}


### PR DESCRIPTION
These patches fixes Unicode support for database, table and column names and also for warning and error messages from MySQL server.

UTF-8 decoding is enabled only if mysql_enable_utf8 is enabled. Otherwise those patches have no effect. For UTF-8 decoding of error messages is DBI of version 1.635 required.

Fixes bug: https://rt.cpan.org/Public/Bug/Display.html?id=120141