### PR TITLE
Fix type conversions

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4547,8 +4547,7 @@ process:
           if (!(fields[i].flags & ZEROFILL_FLAG))
           {
             /* Coerce to dobule and set scalar as NV */
-            (void) SvNV(sv);
-            SvNOK_only(sv);
+            sv_setnv(sv, SvNV(sv));
           }
           break;
 
@@ -4557,15 +4556,9 @@ process:
           {
             /* Coerce to integer and set scalar as UV resp. IV */
             if (fields[i].flags & UNSIGNED_FLAG)
-            {
-              (void) SvUV(sv);
-              SvIOK_only_UV(sv);
-            }
+              sv_setuv(sv, SvUV(sv));
             else
-            {
-              (void) SvIV(sv);
-              SvIOK_only(sv);
-            }
+              sv_setiv(sv, SvIV(sv));
           }
           break;
 


### PR DESCRIPTION
Calling SvNV() for magical scalar is not enough for float type conversion.
It caused problem for Amavis in tainted mode -- all float values were zero.
On the other hand SvIV() and SvUV() seems to work fine. To be sure that
correct value of float is in scalar use sv_setnv() with explicit NV float
value. Similar code is changed also for integers IV/UV.

This patch should fix reported Amavis bug:
https://github.com/perl5-dbi/DBD-mysql/issues/78

See also reported perl bug about SvNV():
https://rt.perl.org/Public/Bug/Display.html?id=130801