### PR TITLE
Speed up builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+sudo: false
+
 language: perl
+
 perl:
   - "5.8"
   - "5.10"
@@ -12,6 +15,7 @@ perl:
   - "5.22"
   - "5.22-shrplib"
   - "5.24"
+
 matrix:
   include:
     - perl: "5.20"
@@ -88,6 +92,18 @@ matrix:
 #      env: CONC_DB=MariaDB CONC_VERSION=2.3.2
 #    - perl: "5.20"
 #      env: CONC_DB=MariaDB CONC_VERSION=3.0.1-beta
+
+addons:
+  apt:
+    packages:
+      - libaio-dev
+      - libnuma-dev
+      - libjemalloc-dev
+      - libmysqlclient-dev
+      - libmysqld-dev
+      - libwrap0-dev
+      - libstdc++5
+
 before_install:
   - if [ "$DB" = "MySQL" ]; then
       case "$VERSION" in
@@ -128,16 +144,7 @@ before_install:
   - if [ -n "$CONC_DB" ]; then
       wget "$CONC_URL" -O "$CONC_FILE" || exit 1 ;
     fi
-  - sudo apt-get update -qq
-  - if [ -n "$DB" ]; then
-      sudo apt-get install -qq libaio-dev libnuma-dev libjemalloc-dev || exit 1 ;
-      sudo apt-get remove -qq mysql-client mysql-client-5.5 mysql-client-core-5.5 mysql-common mysql-server mysql-server-5.5 mysql-server-core-5.5 libmysqlclient-dev libmysqlclient18 || exit 1 ;
-    elif [ -n "$CONC_DB" ]; then
-      sudo apt-get remove -qq libmysqlclient-dev || exit 1 ;
-      sudo apt-get install -qq libstdc++5 || exit 1 ;
-    else
-      sudo apt-get install -qq libmysqlclient-dev libmysqld-dev libwrap0-dev || exit 1 ;
-    fi
+
 install:
   - perlbrew install-cpanm --force --notest
   - cpanm --quiet --notest --skip-satisfied DBI Devel::CheckLib
@@ -145,13 +152,7 @@ install:
   - if [ -n "$DB" ]; then
       cpanm --quiet --notest --skip-satisfied MySQL::Sandbox || exit 1 ;
       make_sandbox --export_binaries "$SANDBOX_FILE" -- --sandbox_port 3310 --sandbox_directory msb --no_confirm || exit 1 ;
-      export DBD_MYSQL_TESTUSER=msandbox ;
-      export DBD_MYSQL_TESTPASSWORD=msandbox ;
-      export DBD_MYSQL_TESTHOST=127.0.0.1 ;
-      export DBD_MYSQL_TESTPORT=3310 ;
-    elif [ -n "$CONC_DB" ]; then
-      export DBD_MYSQL_TESTHOST=127.0.0.1 ;
-      export DBD_MYSQL_TESTPORT=3306 ;
+      mysqladmin -u root shutdown || exit 1 ;
     fi
   - if [ -n "$CONC_DB" ]; then
       mkdir -p "$HOME/conc" ;
@@ -161,12 +162,28 @@ install:
       fi ;
       if [ -x $HOME/conc/bin/mysql_config ]; then
         sed 's/-l "/-lmysqlclient "/g' -i "$HOME/conc/bin/mysql_config" || exit 1 ;
-        export DBD_MYSQL_CONFIG="$HOME/conc/bin/mysql_config" ;
       else
         INCLUDE_PATH=`find "$HOME/conc" -name "mysql.h" | sort | head -1` ;
         if [ -z "$INCLUDE_PATH" ]; then echo "File mysql.h was not found"; exit 1; fi ;
         LIB_PATH=`find "$HOME/conc" -name "lib*.so" | sort | head -1` ;
         if [ -z "$INCLUDE_PATH" ]; then echo "File lib*.so was not found"; exit 1; fi ;
+      fi ;
+    fi
+
+before_script:
+  - if [ -n "$DB" ]; then
+      export DBD_MYSQL_TESTUSER=msandbox ;
+      export DBD_MYSQL_TESTPASSWORD=msandbox ;
+      export DBD_MYSQL_TESTHOST=127.0.0.1 ;
+      export DBD_MYSQL_TESTPORT=3310 ;
+    elif [ -n "$CONC_DB" ]; then
+      export DBD_MYSQL_TESTHOST=127.0.0.1 ;
+      export DBD_MYSQL_TESTPORT=3306 ;
+    fi
+  - if [ -n "$CONC_DB" ]; then
+      if [ -x $HOME/conc/bin/mysql_config ]; then
+        export DBD_MYSQL_CONFIG="$HOME/conc/bin/mysql_config" ;
+      else
         export DBD_MYSQL_CFLAGS="-I`dirname $INCLUDE_PATH`" ;
         export DBD_MYSQL_LIBS="-L`dirname $LIB_PATH` -l`echo $LIB_PATH | sed 's/.*\/lib//;s/\.so//'`" ;
         export DBD_MYSQL_CONFIG="skip" ;
@@ -176,8 +193,12 @@ install:
     else
       export DBD_MYSQL_FORCE_EMBEDDED=1 ;
     fi
+  - export HARNESS_OPTIONS=j1
   - export RELEASE_TESTING=1
   - export CONNECTION_TESTING=1
   - export SKIP_CRASH_TESTING=1
+
 script:
-  - perl Makefile.PL && make disttest
+  - rm -f t/mysql.mtest
+  - perl Makefile.PL
+  - make disttest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: false
 
+cache:
+  directories:
+    - $HOME/cache
+    - $HOME/.cpan/sources
+
 language: perl
 
 perl:
@@ -115,17 +120,20 @@ before_install:
         8.0.*)       SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux-glibc2.12-x86_64.tar.gz ;;
         *)           echo "Unsupported MySQL version '$VERSION'"; exit 1 ;;
       esac ;
-      SANDBOX_FILE="$HOME/$(basename "$SANDBOX_URL")" ;
+      SANDBOX_CACHE_FILE="$HOME/cache/$(basename "$SANDBOX_URL")" ;
     elif [ "$DB" = "MariaDB" ]; then
       SANDBOX_URL=https://downloads.mariadb.com/MariaDB/mariadb-$VERSION/bintar-linux-x86_64/mariadb-$VERSION-linux-x86_64.tar.gz ;
-      SANDBOX_FILE="$HOME/mariadb-$VERSION-linux-x86_64.tar.gz" ;
+      SANDBOX_CACHE_FILE="$HOME/cache/mariadb-$VERSION-linux-x86_64.tar.gz" ;
     elif [ -n "$DB" ]; then
       echo "Unsupported DB '$DB'"; exit 1 ;
     fi
   - if [ -n "$DB" ]; then
       export SANDBOX_HOME="$HOME/sandbox" ;
       export SANDBOX_BINARY="$SANDBOX_HOME/binary" ;
-      wget "$SANDBOX_URL" -O "$SANDBOX_FILE" || exit 1 ;
+      export SANDBOX_FILE="$SANDBOX_HOME/$(basename "$SANDBOX_CACHE_FILE")" ;
+      if [ ! -f "$SANDBOX_CACHE_FILE" ]; then wget "$SANDBOX_URL" -O "$SANDBOX_CACHE_FILE" || exit 1; fi ;
+      mkdir -p "$SANDBOX_HOME" || exit 1 ;
+      ln -s "$SANDBOX_CACHE_FILE" "$SANDBOX_FILE" || exit 1 ;
     fi
   - if [ "$CONC_DB" = "MySQL" ]; then
       case "$CONC_VERSION" in
@@ -134,15 +142,15 @@ before_install:
         6.1.*)       CONC_URL=https://dev.mysql.com/get/mysql-connector-c-$CONC_VERSION-linux-glibc2.5-x86_64.tar.gz ;;
         *)           echo "Unsupported MySQL Connector/C version '$VERSION'"; exit 1 ;;
       esac ;
-      CONC_FILE="$HOME/$(basename "$CONC_URL")" ;
+      CONC_FILE="$HOME/cache/$(basename "$CONC_URL")" ;
     elif [ "$CONC_DB" = "MariaDB" ]; then
       CONC_URL=https://downloads.mariadb.com/Connectors/c/connector-c-${CONC_VERSION/-*/}/mariadb-connector-c-$CONC_VERSION-linux-x86_64.tar.gz ;
-      CONC_FILE="$HOME/mariadb-connector-c-$CONC_VERSION-linux-x86_64.tar.gz" ;
+      CONC_FILE="$HOME/cache/mariadb-connector-c-$CONC_VERSION-linux-x86_64.tar.gz" ;
     elif [ -n "$CONC_DB" ]; then
       echo "Unsupported Connector/C '$CONC_DB'"; exit 1 ;
     fi
   - if [ -n "$CONC_DB" ]; then
-      wget "$CONC_URL" -O "$CONC_FILE" || exit 1 ;
+      if [ ! -f "$CONC_FILE" ]; then wget "$CONC_URL" -O "$CONC_FILE" || exit 1; fi ;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,11 +138,12 @@ before_install:
     else
       sudo apt-get install -qq libmysqlclient-dev libmysqld-dev libwrap0-dev || exit 1 ;
     fi
-  - perlbrew install-cpanm -f
 install:
-  - cpanm --quiet DBI Test::Pod Test::Deep Test::DistManifest Proc::ProcessTable Devel::CheckLib
+  - perlbrew install-cpanm --force --notest
+  - cpanm --quiet --notest --skip-satisfied DBI Devel::CheckLib
+  - cpanm --quiet --notest --skip-satisfied --installdeps --with-configure --with-develop --with-recommends --with-suggests .
   - if [ -n "$DB" ]; then
-      cpanm --quiet MySQL::Sandbox || exit 1 ;
+      cpanm --quiet --notest --skip-satisfied MySQL::Sandbox || exit 1 ;
       make_sandbox --export_binaries "$SANDBOX_FILE" -- --sandbox_port 3310 --sandbox_directory msb --no_confirm || exit 1 ;
       export DBD_MYSQL_TESTUSER=msandbox ;
       export DBD_MYSQL_TESTPASSWORD=msandbox ;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -390,12 +390,19 @@ if (eval $ExtUtils::MakeMaker::VERSION >= 5.43) {
     LICENSE => 'perl',
     MIN_PERL_VERSION => '5.008001',
     META_MERGE => {
+      'meta-spec' => {
+        version => 2,
+      },
       resources => {
-        repository => 'https://github.com/perl5-dbi/DBD-mysql',
-        MailingList => 'mailto:dbi-dev@perl.org',
+        repository  => {
+          url  => 'git://github.com/perl5-dbi/DBD-mysql.git',
+          web  => 'https://github.com/perl5-dbi/DBD-mysql',
+          type => 'git',
+        },
+        x_MailingList => 'mailto:dbi-dev@perl.org',
         license     => 'http://dev.perl.org/licenses/',
         homepage    => 'http://dbi.perl.org/',
-        IRC         => 'irc://irc.perl.org/#dbi',
+        x_IRC       => 'irc://irc.perl.org/#dbi',
       },
       x_contributors => [
         # a list of our awesome contributors generated from git
@@ -465,6 +472,7 @@ if (eval $ExtUtils::MakeMaker::VERSION >= 5.43) {
     CONFIGURE_REQUIRES => { 'DBI' => 1.609,
                             'Data::Dumper' => 0,
                             'Devel::CheckLib' => 0,
+                            'ExtUtils::MakeMaker' => 0,
     },
   );
 }
@@ -873,6 +881,33 @@ sub WriteMakefile1 {  #Written by Alexandr Ciornii, version 0.21. Added by eumm-
   $eumm_version=eval $eumm_version;
   die "EXTRA_META is deprecated" if exists $params{EXTRA_META};
   die "License not specified" if not exists $params{LICENSE};
+  if ($params{META_MERGE} and $params{META_MERGE}->{'meta-spec'}->{version} >= 2 and $eumm_version < 6.68) {
+    #EUMM 6.68 has problems with meta-spec 2
+    delete $params{META_MERGE}->{'meta-spec'};
+    if ($params{META_MERGE}->{resources}) {
+      foreach (values %{$params{META_MERGE}->{resources}}) {
+        $_ = $_->{url} || $_->{web} if ref $_ eq 'HASH';
+      }
+    }
+    if ($params{META_MERGE}->{prereqs}) {
+      $params{CONFIGURE_REQUIRES} = { %{$params{CONFIGURE_REQUIRES} || {'ExtUtils::MakeMaker' => 0}}, %{$params{META_MERGE}->{prereqs}->{configure}->{requires} || {}} };
+      $params{BUILD_REQUIRES} = { %{$params{BUILD_REQUIRES} || {'ExtUtils::MakeMaker' => 0}}, %{$params{META_MERGE}->{prereqs}->{build}->{requires} || {}} };
+      $params{TEST_REQUIRES} = { %{$params{TEST_REQUIRES} || {}}, %{$params{META_MERGE}->{prereqs}->{test}->{requires} || {}} };
+      $params{PREREQ_PM} = { %{$params{PREREQ_PM} || {}}, %{$params{META_MERGE}->{prereqs}->{runtime}->{requires} || {}} };
+      my @recommends = (
+        %{$params{META_MERGE}->{prereqs}->{configure}->{recommends} || {}},
+        %{$params{META_MERGE}->{prereqs}->{configure}->{suggests} || {}},
+        %{$params{META_MERGE}->{prereqs}->{build}->{recommends} || {}},
+        %{$params{META_MERGE}->{prereqs}->{build}->{suggests} || {}},
+        %{$params{META_MERGE}->{prereqs}->{test}->{recommends} || {}},
+        %{$params{META_MERGE}->{prereqs}->{test}->{suggests} || {}},
+        %{$params{META_MERGE}->{prereqs}->{runtime}->{recommends} || {}},
+        %{$params{META_MERGE}->{prereqs}->{runtime}->{suggests} || {}},
+      );
+      $params{META_MERGE}->{recommends} = { %{$params{META_MERGE}->{recommends} || {}}, @recommends } if @recommends;
+      delete $params{META_MERGE}->{prereqs};
+    }
+  }
   if ($params{BUILD_REQUIRES} and $eumm_version < 6.5503) {
     #EUMM 6.5502 has problems with BUILD_REQUIRES
     $params{PREREQ_PM}={ %{$params{PREREQ_PM} || {}} , %{$params{BUILD_REQUIRES}} };

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -463,6 +463,17 @@ if (eval $ExtUtils::MakeMaker::VERSION >= 5.43) {
         'zefram <zefram@fysh.org>',
         'zentooo <ankerasoy@gmail.com>',
       ],
+      prereqs => {
+        test => {
+          recommends => {
+            'Proc::ProcessTable' => 0,
+          },
+          suggests => {
+            'Test::Pod' => '1.00',
+            'Test::DistManifest' => 0,
+          },
+        },
+      },
     },
     TEST_REQUIRES => { 'bigint'       => 0,
                        'Test::Simple' => '0.90',


### PR DESCRIPTION
* Upgrade meta-spec to version 2
* Add recommends and suggests tests dependences
* Automatically install all needed dependences by cpanm on Travis
* Run Travis on container-based infrastructure
* Enable Travis cache for cpan sources and MySQL/MariaDB binaries