### PR TITLE
Improve SSL settings, reflect changes for BACKRONYM and Riddle vulnerabilities, enforce SSL encryption when mysql_ssl=1 is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,11 @@ matrix:
     - perl: "5.20"
       env: DB=MySQL VERSION=5.5.47
     - perl: "5.20"
+      env: DB=MySQL VERSION=5.5.49
+    - perl: "5.20"
       env: DB=MySQL VERSION=5.5.54
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.5.55
     - perl: "5.20"
       env: DB=MySQL VERSION=5.6.10
     - perl: "5.20"
@@ -46,27 +50,49 @@ matrix:
     - perl: "5.20"
       env: DB=MySQL VERSION=5.6.35
     - perl: "5.20"
+      env: DB=MySQL VERSION=5.6.36
+    - perl: "5.20"
       env: DB=MySQL VERSION=5.7.8-rc
     - perl: "5.20"
+      env: DB=MySQL VERSION=5.7.11
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.7.12
+    - perl: "5.20"
       env: DB=MySQL VERSION=5.7.17
+    - perl: "5.20"
+      env: DB=MySQL VERSION=5.7.18
     - perl: "5.20"
       env: DB=MySQL VERSION=8.0.0-dmr
     - perl: "5.20"
       env: DB=MariaDB VERSION=5.5.40
     - perl: "5.20"
+      env: DB=MariaDB VERSION=5.5.44
+    - perl: "5.20"
       env: DB=MariaDB VERSION=5.5.47
     - perl: "5.20"
       env: DB=MariaDB VERSION=5.5.54
     - perl: "5.20"
+      env: DB=MariaDB VERSION=5.5.55
+    - perl: "5.20"
       env: DB=MariaDB VERSION=10.0.14
     - perl: "5.20"
+      env: DB=MariaDB VERSION=10.0.20
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=10.0.23
+    - perl: "5.20"
       env: DB=MariaDB VERSION=10.0.29
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=10.0.30
     - perl: "5.20"
       env: DB=MariaDB VERSION=10.1.2
     - perl: "5.20"
       env: DB=MariaDB VERSION=10.1.8
     - perl: "5.20"
+      env: DB=MariaDB VERSION=10.1.11
+    - perl: "5.20"
       env: DB=MariaDB VERSION=10.1.20
+    - perl: "5.20"
+      env: DB=MariaDB VERSION=10.1.22
     - perl: "5.20"
       env: DB=MariaDB VERSION=10.2.0
     - perl: "5.20"
@@ -76,6 +102,14 @@ matrix:
 #      env: DB=MariaDB VERSION=10.2.2
 #    - perl: "5.20"
 #      env: DB=MariaDB VERSION=10.2.3
+# Incompatible with DBD::mysql due to broken something in libmysqlclient
+#    - perl: "5.20"
+#      env: DB=MariaDB VERSION=10.2.4
+#    - perl: "5.20"
+#      env: DB=MariaDB VERSION=10.2.5
+# Not supported by MySQL::Sandbox yet
+#    - perl: "5.20"
+#      env: DB=MariaDB VERSION=10.3.0
     - perl: "5.20"
       env: CONC_DB=MySQL CONC_VERSION=6.0.0-beta
     - perl: "5.20"

--- a/MANIFEST
+++ b/MANIFEST
@@ -72,6 +72,8 @@ t/88async-multi-stmts.t
 t/89async-method-check.t
 t/90utf8_params.t
 t/91errcheck.t
+t/92ssl_backronym_vulnerability.t
+t/92ssl_riddle_vulnerability.t
 t/99_bug_server_prepare_blob_null.t
 t/cve-2017-3302.t
 t/lib.pl

--- a/MANIFEST
+++ b/MANIFEST
@@ -72,6 +72,7 @@ t/88async-multi-stmts.t
 t/89async-method-check.t
 t/90utf8_params.t
 t/91errcheck.t
+t/92ssl_optional.t
 t/92ssl_backronym_vulnerability.t
 t/92ssl_riddle_vulnerability.t
 t/99_bug_server_prepare_blob_null.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -72,6 +72,7 @@ t/88async-multi-stmts.t
 t/89async-method-check.t
 t/90utf8_params.t
 t/91errcheck.t
+t/92ssl_connection.t
 t/92ssl_optional.t
 t/92ssl_backronym_vulnerability.t
 t/92ssl_riddle_vulnerability.t

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2091,6 +2091,9 @@ MYSQL *mysql_dr_connect(
   #endif
 	    }
 
+	    if ((svp = hv_fetch(hv, "mysql_ssl_optional", 18, FALSE)) && *svp)
+	      ssl_enforce = !SvTRUE(*svp);
+
 	    if ((svp = hv_fetch(hv, "mysql_ssl_client_key", 20, FALSE)) && *svp)
 	      client_key = SvPV(*svp, lna);
 
@@ -2120,7 +2123,9 @@ MYSQL *mysql_dr_connect(
 
   #ifdef HAVE_SSL_MODE
 
-	    if (ssl_verify)
+	    if (!ssl_enforce)
+	      ssl_mode = SSL_MODE_PREFERRED;
+	    else if (ssl_verify)
 	      ssl_mode = SSL_MODE_VERIFY_IDENTITY;
 	    else if (ca_file || ca_path)
 	      ssl_mode = SSL_MODE_VERIFY_CA;
@@ -2133,6 +2138,7 @@ MYSQL *mysql_dr_connect(
 
   #else
 
+	    if (ssl_enforce) {
     #if defined(HAVE_SSL_MODE_ONLY_REQUIRED)
 	      ssl_mode = SSL_MODE_REQUIRED;
 	      if (mysql_options(sock, MYSQL_OPT_SSL_MODE, &ssl_mode) != 0) {
@@ -2158,9 +2164,17 @@ MYSQL *mysql_dr_connect(
 	      set_ssl_error(sock, "Enforcing SSL encryption is not supported");
 	      return NULL;
     #endif
+	    }
+
+    #ifdef HAVE_SSL_VERIFY
+	    if (!ssl_enforce && ssl_verify && ssl_verify_also_enforce_ssl()) {
+	      set_ssl_error(sock, "mysql_ssl_optional=1 with mysql_ssl_verify_server_cert=1 is not supported");
+	      return NULL;
+	    }
+    #endif
 
 	    if (ssl_verify) {
-	      if (!ssl_verify_usable() && ssl_verify_set) {
+	      if (!ssl_verify_usable() && ssl_enforce && ssl_verify_set) {
 	        set_ssl_error(sock, "mysql_ssl_verify_server_cert=1 is broken by current version of MySQL client");
 	        return NULL;
 	      }

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2993,6 +2993,14 @@ SV* dbd_db_FETCH_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv)
       result= serverinfo ?
         sv_2mortal(newSVpvn(serverinfo, strlen(serverinfo))) : &PL_sv_undef;
     } 
+#if ((MYSQL_VERSION_ID >= 50023 && MYSQL_VERSION_ID < 50100) || MYSQL_VERSION_ID >= 50111)
+    else if (kl == 10 && strEQ(key, "ssl_cipher"))
+    {
+      const char* ssl_cipher = mysql_get_ssl_cipher(imp_dbh->pmysql);
+      result= ssl_cipher ?
+        sv_2mortal(newSVpvn(ssl_cipher, strlen(ssl_cipher))) : &PL_sv_undef;
+    }
+#endif
     else if (kl == 13 && strEQ(key, "serverversion"))
       result= sv_2mortal(my_ulonglong2sv(aTHX_ mysql_get_server_version(imp_dbh->pmysql)));
     else if (strEQ(key, "sock"))

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -63,20 +63,10 @@
 #define LIMIT_PLACEHOLDER_VERSION 50007
 #define GEO_DATATYPE_VERSION 50007
 #define NEW_DATATYPE_VERSION 50003
-#define SSL_VERIFY_VERSION 50023
-#define SSL_LAST_VERIFY_VERSION 50799
-#define SSL_ENFORCE_VERSION 50703
-#define SSL_LAST_ENFORCE_VERSION 50799
 #define MYSQL_VERSION_5_0 50001
-#define MARIADB_VERSION_10 100000
 /* This is to avoid the ugly #ifdef mess in dbdimp.c */
 #if MYSQL_VERSION_ID < SQL_STATE_VERSION
 #define mysql_sqlstate(svsock) (NULL)
-#endif
-#if MYSQL_VERSION_ID > 50710 && MYSQL_VERSION_ID < MARIADB_VERSION_10
-#if MYSQL_VERSION_ID != 60000  /* MySQL Connector/C 6.0 */
-#define MYSQL_SSL_MODE
-#endif
 #endif
 /*
  * This is the versions of libmysql that supports MySQL Fabric.
@@ -100,6 +90,54 @@
 
 #define true 1
 #define false 0
+
+/*
+ * Check which SSL settings are supported by API at compile time
+ */
+
+/* Use mysql_options with MYSQL_OPT_SSL_VERIFY_SERVER_CERT */
+#if ((MYSQL_VERSION_ID >= 50023 && MYSQL_VERSION_ID < 50100) || MYSQL_VERSION_ID >= 50111) && (MYSQL_VERSION_ID < 80000 || defined(MARIADB_BASE_VERSION))
+#define HAVE_SSL_VERIFY
+#endif
+
+/* Use mysql_options with MYSQL_OPT_SSL_ENFORCE */
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 50703 && MYSQL_VERSION_ID < 80000 && MYSQL_VERSION_ID != 60000
+#define HAVE_SSL_ENFORCE
+#endif
+
+/* Use mysql_options with MYSQL_OPT_SSL_MODE */
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 50711 && MYSQL_VERSION_ID != 60000
+#define HAVE_SSL_MODE
+#endif
+
+/* Use mysql_options with MYSQL_OPT_SSL_MODE, but only SSL_MODE_REQUIRED is supported */
+#if !defined(MARIADB_BASE_VERSION) && ((MYSQL_VERSION_ID >= 50636 && MYSQL_VERSION_ID < 50700) || (MYSQL_VERSION_ID >= 50555 && MYSQL_VERSION_ID < 50600))
+#define HAVE_SSL_MODE_ONLY_REQUIRED
+#endif
+
+/*
+ * Check which SSL settings are supported by API at runtime
+ */
+
+/* MYSQL_OPT_SSL_VERIFY_SERVER_CERT automatically enforce SSL mode */
+PERL_STATIC_INLINE bool ssl_verify_also_enforce_ssl(void) {
+#ifdef MARIADB_BASE_VERSION
+	my_ulonglong version = mysql_get_client_version();
+	return ((version >= 50544 && version < 50600) || (version >= 100020 && version < 100100) || version >= 100106);
+#else
+	return false;
+#endif
+}
+
+/* MYSQL_OPT_SSL_VERIFY_SERVER_CERT is not vulnerable (CVE-2016-2047) and can be used */
+PERL_STATIC_INLINE bool ssl_verify_usable(void) {
+	my_ulonglong version = mysql_get_client_version();
+#ifdef MARIADB_BASE_VERSION
+	return ((version >= 50547 && version < 50600) || (version >= 100023 && version < 100100) || version >= 100110);
+#else
+	return ((version >= 50549 && version < 50600) || (version >= 50630 && version < 50700) || version >= 50712);
+#endif
+}
 
 /*
  *  The following are return codes passed in $h->err in case of

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1228,6 +1228,22 @@ cipher in the list is supported, encrypted connections will not work.
   mysql_ssl_cipher=AES128-SHA
   mysql_ssl_cipher=DHE-RSA-AES256-SHA:AES128-SHA
 
+=item mysql_ssl_optional
+
+Setting C<mysql_ssl_optional> to true disables strict SSL enforcement
+and makes SSL connection optional.  This option opens security hole
+for man-in-the-middle attacks.  Default value is false which means
+that C<mysql_ssl> set to true enforce SSL encryption.
+
+This option was introduced in 4.043 version of DBD::mysql.  Due to
+L<The BACKRONYM|http://backronym.fail/> and L<The Riddle|http://riddle.link/>
+vulnerabilities in libmysqlclient library, enforcement of SSL
+encryption was not possbile and therefore C<mysql_ssl_optional=1>
+was effectively set for all DBD::mysql versions prior to 4.043.
+Starting with 4.043, DBD::mysql with C<mysql_ssl=1> could refuse
+connection to MySQL server if underlaying libmysqlclient library is
+vulnerable.  Option C<mysql_ssl_optional> can be used to make SSL
+connection vulnerable.
 
 =item mysql_local_infile
 

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1167,7 +1167,10 @@ location for the socket than that built into the client.
 A true value turns on the CLIENT_SSL flag when connecting to the MySQL
 database:
 
-  mysql_ssl=1
+When enabling SSL encryption you should set also other SSL options,
+at least mysql_ssl_ca_file or mysql_ssl_ca_path.
+
+  mysql_ssl=1 mysql_ssl_verify_server_cert=1 mysql_ssl_ca_file=/path/to/ca_cert.pem
 
 This means that your communication with the server will be encrypted.
 
@@ -1175,21 +1178,54 @@ Please note that this can only work if you enabled SSL when compiling
 DBD::mysql; this is the default starting version 4.034.
 See L<DBD::mysql::INSTALL> for more details.
 
-If you turn mysql_ssl on, you might also wish to use the following
-flags:
-
-=item mysql_ssl_client_key
-
-=item mysql_ssl_client_cert
-
 =item mysql_ssl_ca_file
+
+The path to a file in PEM format that contains a list of trusted SSL
+certificate authorities.
+
+When set MySQL server certificate is checked that it is signed by some
+CA certificate in the list.  Common Name value is not verified unless
+C<mysql_ssl_verify_server_cert> is enabled.
 
 =item mysql_ssl_ca_path
 
+The path to a directory that contains trusted SSL certificate authority
+certificates in PEM format.
+
+When set MySQL server certificate is checked that it is signed by some
+CA certificate in the list.  Common Name value is not verified unless
+C<mysql_ssl_verify_server_cert> is enabled.
+
+Please note that this option is supported only if your MySQL client was
+compiled with OpenSSL library, and not with default yaSSL library.
+
+=item mysql_ssl_verify_server_cert
+
+Checks the server's Common Name value in the certificate that the server
+sends to the client.  The client verifies that name against the host name
+the client uses for connecting to the server, and the connection fails if
+there is a mismatch.  For encrypted connections, this option helps prevent
+man-in-the-middle attacks.
+
+Verification of the host name is disabled by default.
+
+=item mysql_ssl_client_key
+
+The name of the SSL key file in PEM format to use for establishing
+a secure connection.
+
+=item mysql_ssl_client_cert
+
+The name of the SSL certificate file in PEM format to use for
+establishing a secure connection.
+
 =item mysql_ssl_cipher
 
-These are used to specify the respective parameters of a call
-to mysql_ssl_set, if mysql_ssl is turned on.
+A list of permissible ciphers to use for connection encryption.  If no
+cipher in the list is supported, encrypted connections will not work.
+
+  mysql_ssl_cipher=AES128-SHA
+  mysql_ssl_cipher=DHE-RSA-AES256-SHA:AES128-SHA
 
 
 =item mysql_local_infile

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1165,7 +1165,8 @@ location for the socket than that built into the client.
 =item mysql_ssl
 
 A true value turns on the CLIENT_SSL flag when connecting to the MySQL
-database:
+server and enforce SSL encryption.  A false value (which is default)
+disable SSL encryption with the MySQL server.
 
 When enabling SSL encryption you should set also other SSL options,
 at least mysql_ssl_ca_file or mysql_ssl_ca_path.

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1446,18 +1446,19 @@ handles (read only):
 
   $errno = $dbh->{'mysql_errno'};
   $error = $dbh->{'mysql_error'};
-  $info = $dbh->{'mysql_hostinfo'};
+  $hostinfo = $dbh->{'mysql_hostinfo'};
   $info = $dbh->{'mysql_info'};
   $insertid = $dbh->{'mysql_insertid'};
-  $info = $dbh->{'mysql_protoinfo'};
-  $info = $dbh->{'mysql_serverinfo'};
-  $info = $dbh->{'mysql_stat'};
-  $threadId = $dbh->{'mysql_thread_id'};
+  $protoinfo = $dbh->{'mysql_protoinfo'};
+  $serverinfo = $dbh->{'mysql_serverinfo'};
+  $ssl_cipher = $dbh->{'mysql_ssl_cipher'};
+  $stat = $dbh->{'mysql_stat'};
+  $thread_id = $dbh->{'mysql_thread_id'};
 
 These correspond to mysql_errno(), mysql_error(), mysql_get_host_info(),
 mysql_info(), mysql_insert_id(), mysql_get_proto_info(),
-mysql_get_server_info(), mysql_stat() and mysql_thread_id(),
-respectively.
+mysql_get_server_info(), mysql_stat(), mysql_get_ssl_cipher()
+and mysql_thread_id() respectively.
 
 =over 2
 
@@ -1481,6 +1482,19 @@ against:
   print "$dbh->{mysql_serverversion}\n";
 
   50200
+
+=item mysql_ssl_cipher
+
+Returns the SSL encryption cipher used for the given connection to
+the server.  In case SSL encryption was not enabled with C<mysql_ssl>
+or was not established returns undef.
+
+  my $ssl_cipher = $dbh->{mysql_ssl_cipher};
+  if (defined $ssl_cipher) {
+    print "Connection with server is encrypted with cipher: $ssl_cipher\n";
+  } else {
+    print "Connection with server is not encrypted\n";
+  }
 
 =item mysql_dbd_stats
 

--- a/t/92ssl_backronym_vulnerability.t
+++ b/t/92ssl_backronym_vulnerability.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+
+use vars qw($test_dsn $test_user $test_password);
+use lib 't', '.';
+require "lib.pl";
+
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 1 });
+my $have_ssl = eval { $dbh->selectrow_hashref("SHOW VARIABLES WHERE Variable_name = 'have_ssl'") };
+$dbh->disconnect();
+plan skip_all => 'Server supports SSL connections, cannot test false-positive enforcement' if $have_ssl and $have_ssl->{Value} eq 'YES';
+
+plan tests => 4;
+
+$dbh = DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 0, mysql_ssl => 1 });
+ok(!defined $dbh, 'DBD::mysql refused connection to non-SSL server with mysql_ssl=1 and correct user and password');
+is($DBI::err, 2026, 'DBD::mysql error message is SSL related') or diag('Error message: ' . ($DBI::errstr || 'unknown'));
+
+$dbh = DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 0, mysql_ssl => 1, mysql_ssl_verify_server_cert => 1, mysql_ssl_ca_file => "" });
+ok(!defined $dbh, 'DBD::mysql refused connection to non-SSL server with mysql_ssl=1, mysql_ssl_verify_server_cert=1 and correct user and password');
+is($DBI::err, 2026, 'DBD::mysql error message is SSL related') or diag('Error message: ' . ($DBI::errstr || 'unknown'));

--- a/t/92ssl_connection.t
+++ b/t/92ssl_connection.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+
+use vars qw($test_dsn $test_user $test_password);
+use lib 't', '.';
+require "lib.pl";
+
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 1 });
+my $have_ssl = eval { $dbh->selectrow_hashref("SHOW VARIABLES WHERE Variable_name = 'have_ssl'") };
+$dbh->disconnect();
+plan skip_all => 'Server does not support SSL connections' unless $have_ssl and $have_ssl->{Value} eq 'YES';
+
+plan tests => 4;
+
+$dbh = DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 0, mysql_ssl => 1, mysql_ssl_optional => 1 });
+ok(defined $dbh, 'DBD::mysql supports mysql_ssl=1 with mysql_ssl_optional=1 and connect to server') or diag('Error code: ' . ($DBI::err || 'none') . "\n" . 'Error message: ' . ($DBI::errstr || 'unknown'));
+
+ok(defined $dbh && defined $dbh->{mysql_ssl_cipher}, 'SSL connection was established') and diag("mysql_ssl_cipher is: ". $dbh->{mysql_ssl_cipher});
+
+$dbh = DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 0, mysql_ssl => 1 });
+if (defined $dbh) {
+  pass('DBD::mysql supports mysql_ssl=1 without mysql_ssl_optional=1 and connect to server');
+  ok(defined $dbh->{mysql_ssl_cipher}, 'SSL connection was established');
+} else {
+  is($DBI::errstr, 'SSL connection error: Enforcing SSL encryption is not supported', 'DBD::mysql supports mysql_ssl=1 without mysql_ssl_optional=1 and fail because cannot enforce SSL encryption') or diag('Error message: ' . ($DBI::errstr || 'unknown'));
+  is($DBI::err, 2026, 'DBD::mysql error code is SSL related') or diag('Error code: ' . ($DBI::err || 'unknown'));
+}

--- a/t/92ssl_optional.t
+++ b/t/92ssl_optional.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+
+use vars qw($test_dsn $test_user $test_password);
+use lib 't', '.';
+require "lib.pl";
+
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 1 });
+my $have_ssl = eval { $dbh->selectrow_hashref("SHOW VARIABLES WHERE Variable_name = 'have_ssl'") };
+$dbh->disconnect();
+plan skip_all => 'Server supports SSL connections, cannot test fallback to plain text' if $have_ssl and $have_ssl->{Value} eq 'YES';
+
+plan tests => 2;
+
+$dbh = DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 0, mysql_ssl => 1, mysql_ssl_optional => 1 });
+ok(defined $dbh, 'DBD::mysql supports mysql_ssl_optional=1 and connect via plain text protocol when SSL is not supported by server') or diag('Error code: ' . ($DBI::err || 'none') . "\n" . 'Error message: ' . ($DBI::errstr || 'unknown'));
+
+$dbh = DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 0, mysql_ssl => 1, mysql_ssl_optional => 1, mysql_ssl_ca_file => "" });
+ok(defined $dbh, 'DBD::mysql supports mysql_ssl_optional=1 and connect via plain text protocol when SSL is not supported by server even with mysql_ssl_ca_file') or diag('Error code: ' . ($DBI::err || 'none') . "\n" . 'Error message: ' . ($DBI::errstr || 'unknown'));

--- a/t/92ssl_riddle_vulnerability.t
+++ b/t/92ssl_riddle_vulnerability.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+
+use vars qw($test_dsn $test_user $test_password);
+use lib 't', '.';
+require "lib.pl";
+
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 1 });
+my $have_ssl = eval { $dbh->selectrow_hashref("SHOW VARIABLES WHERE Variable_name = 'have_ssl'") };
+$dbh->disconnect();
+plan skip_all => 'Server supports SSL connections, cannot test false-positive enforcement' if $have_ssl and $have_ssl->{Value} eq 'YES';
+
+plan tests => 4;
+
+$dbh = DBI->connect($test_dsn, '4yZ73s9qeECdWi', '64heUGwAsVoNqo', { PrintError => 0, RaiseError => 0, mysql_ssl => 1 });
+ok(!defined $dbh, 'DBD::mysql refused connection to non-SSL server with mysql_ssl=1 and incorrect user and password');
+is($DBI::err, 2026, 'DBD::mysql error message is SSL related') or diag('Error message: ' . ($DBI::errstr || 'unknown'));
+
+$dbh = DBI->connect($test_dsn, '4yZ73s9qeECdWi', '64heUGwAsVoNqo', { PrintError => 0, RaiseError => 0, mysql_ssl => 1, mysql_ssl_verify_server_cert => 1, mysql_ssl_ca_file => "" });
+ok(!defined $dbh, 'DBD::mysql refused connection to non-SSL server with mysql_ssl=1, mysql_ssl_verify_server_cert=1 and incorrect user and password');
+is($DBI::err, 2026, 'DBD::mysql error message is SSL related') or diag('Error message: ' . ($DBI::errstr || 'unknown'));


### PR DESCRIPTION
This pull request improve SSL settings by:
* Describing all SSL related attributes in POD documentation
* Reflect changes between different versions of libmysqlclient.so and properly enforce SSL encryption
* Fixed BACKRONYM and Riddle vulnerabilities
* Enforce SSL encryption when mysql_ssl=1 is set
* Add new connection attribute mysql_ssl_optional
* Add new database handle attribute mysql_ssl_cipher

The important change is that DBD::mysql reject connection to MySQL server (also SSL enabled) if mysql_ssl=1 is set and libmysqlclient.so library cannot enforce SSL encryption (because is vulnerable to BACKRONYM or Riddle).

See also discussion at https://github.com/perl5-dbi/DBD-mysql/issues/110