### PR TITLE
Fix build with Connector/C 6.0.x

### DIFF
--- a/dbdimp.h
+++ b/dbdimp.h
@@ -74,7 +74,9 @@
 #define mysql_sqlstate(svsock) (NULL)
 #endif
 #if MYSQL_VERSION_ID > 50710 && MYSQL_VERSION_ID < MARIADB_VERSION_10
+#if MYSQL_VERSION_ID != 60000  /* MySQL Connector/C 6.0 */
 #define MYSQL_SSL_MODE
+#endif
 #endif
 /*
  * This is the versions of libmysql that supports MySQL Fabric.


### PR DESCRIPTION
MySQL Connector/C 6.0.x sets the MySQL version to 6.0.0
MySQL Connector/C 6.1.x sets the MySQL version to 5.7.x

Fixes the broken build as reported in #108 

This defines `MYSQL_SSL_MODE` for MySQL 5.7.11 and up including MySQL 8.0.0.
But excludes 6.0.0 as that's what Connector/C 6.0.x uses for some reason.