### PR TITLE
Tests with Proc::ProcessTable module needs size attribute

### DIFF
--- a/t/60leaks.t
+++ b/t/60leaks.t
@@ -25,6 +25,11 @@ if ($@) {
 eval { require Storable };
 $have_storable = $@ ? 0 : 1;
 
+my $have_pt_size = grep { $_ eq 'size' } Proc::ProcessTable->new('cache_ttys' => $have_storable)->fields;
+if (!$have_pt_size) {
+        plan skip_all => "module Proc::ProcessTable does not support size attribute on current platform\n";
+}
+
 my ($dbh, $sth);
 $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                                             { RaiseError => 1, PrintError => 1, AutoCommit => 0 });

--- a/t/rt86153-reconnect-fail-memory.t
+++ b/t/rt86153-reconnect-fail-memory.t
@@ -23,6 +23,11 @@ if ($@) {
 eval { require Storable };
 $have_storable = $@ ? 0 : 1;
 
+my $have_pt_size = grep { $_ eq 'size' } Proc::ProcessTable->new('cache_ttys' => $have_storable)->fields;
+if (!$have_pt_size) {
+    plan skip_all => "module Proc::ProcessTable does not support size attribute on current platform\n";
+}
+
 plan tests => 3;
 
 sub size {


### PR DESCRIPTION
Do needed check for size attribute at tests startup.

Fixes some tests failure on OpenBSD:

t/60leaks.t ............................. Can't access `size' field in class Proc::ProcessTable::Process at t/60leaks.t line 39.
t/60leaks.t ............................. Dubious, test returned 25 (wstat 6400, 0x1900)

t/rt86153-reconnect-fail-memory.t ....... Can't access `size' field in class Proc::ProcessTable::Process at t/rt86153-reconnect-fail-memory.t line 33.
t/rt86153-reconnect-fail-memory.t ....... Dubious, test returned 25 (wstat 6400, 0x1900)

See: https://github.com/perl5-dbi/DBD-mysql/issues/120