### PR TITLE
Fix tests on Perl On 5.25.10 or greater with -Ddefault_inc_excludes_dot

### DIFF
--- a/t/40server_prepare_crash.t
+++ b/t/40server_prepare_crash.t
@@ -5,7 +5,8 @@ use Test::More;
 use DBI;
 
 use vars qw($test_dsn $test_user $test_password);
-require "t/lib.pl";
+use lib 't', '.';
+require "lib.pl";
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 1, AutoCommit => 0, mysql_server_prepare => 1, mysql_server_prepare_disable_fallback => 1 });
 plan skip_all => "You must have MySQL version 4.1.3 and greater for this test to run" if $dbh->{mysql_clientversion} < 40103 or $dbh->{mysql_serverversion} < 40103;

--- a/t/55utf8_jp.t
+++ b/t/55utf8_jp.t
@@ -6,7 +6,8 @@ use DBI;
 use Encode;
 
 use vars qw($test_dsn $test_user $test_password);
-require "t/lib.pl";
+use lib 't', '.';
+require "lib.pl";
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { mysql_enable_utf8 => 1, PrintError => 1, RaiseError => 1 });
 

--- a/t/cve-2017-3302.t
+++ b/t/cve-2017-3302.t
@@ -6,7 +6,8 @@ if ($ENV{SKIP_CRASH_TESTING}) {
 no warnings 'once';
 use DBI;
 use vars qw($test_dsn $test_user $test_password $test_db);
-require "t/lib.pl";
+use lib 't', '.';
+require "lib.pl";
 eval {
   $dbh = DBI->connect($test_dsn, $test_user, $test_password, {RaiseError => 1, mysql_server_prepare => 1});
 } or do {

--- a/t/magic.t
+++ b/t/magic.t
@@ -5,7 +5,8 @@ use Test::More;
 use DBI;
 
 use vars qw($test_dsn $test_user $test_password);
-require "t/lib.pl";
+use lib 't', '.';
+require "lib.pl";
 
 my $tb = Test::More->builder;
 binmode $tb->failure_output, ":utf8";

--- a/t/rt110983-valid-mysqlfd.t
+++ b/t/rt110983-valid-mysqlfd.t
@@ -5,7 +5,8 @@ use Test::More;
 use DBI;
 
 use vars qw($test_dsn $test_user $test_password);
-require "t/lib.pl";
+use lib 't', '.';
+require "lib.pl";
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 0 });
 

--- a/t/rt118977-zerofill.t
+++ b/t/rt118977-zerofill.t
@@ -5,7 +5,8 @@ use Test::More;
 use DBI;
 
 use vars qw($test_dsn $test_user $test_password);
-require "t/lib.pl";
+use lib 't', '.';
+require "lib.pl";
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 1 });
 

--- a/t/rt25389-bin-case.t
+++ b/t/rt25389-bin-case.t
@@ -4,7 +4,8 @@ use warnings;
 use DBI;
 
 use vars qw($test_dsn $test_user $test_password);
-require "t/lib.pl";
+use lib 't', '.';
+require "lib.pl";
 
 use Test::More;
 

--- a/t/rt50304-column_info_parentheses.t
+++ b/t/rt50304-column_info_parentheses.t
@@ -4,7 +4,8 @@ use warnings;
 use DBI;
 
 use vars qw($test_dsn $test_user $test_password $state);
-require "t/lib.pl";
+use lib 't', '.';
+require "lib.pl";
 
 use Test::More;
 

--- a/t/rt61849-bind-param-buffer-overflow.t
+++ b/t/rt61849-bind-param-buffer-overflow.t
@@ -5,7 +5,8 @@ use Test::More;
 use DBI;
 
 use vars qw($test_dsn $test_user $test_password);
-require "t/lib.pl";
+use lib 't', '.';
+require "lib.pl";
 
 my $INSECURE_VALUE_FROM_USER = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 

--- a/t/rt75353-innodb-lock-timeout.t
+++ b/t/rt75353-innodb-lock-timeout.t
@@ -5,7 +5,8 @@ use Test::More;
 use DBI;
 
 use vars qw($test_dsn $test_user $test_password);
-require "t/lib.pl";
+use lib 't', '.';
+require "lib.pl";
 
 my $dbh1 = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 0 });
 

--- a/t/rt83494-quotes-comments.t
+++ b/t/rt83494-quotes-comments.t
@@ -9,7 +9,8 @@ use DBI;
 use Test::More;
 
 use vars qw($test_dsn $test_user $test_password $state);
-require "t/lib.pl";
+use lib 't', '.';
+require "lib.pl";
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });


### PR DESCRIPTION
Some tests do not include dot in %INC and fails with error:
Can't locate t/lib.pl in @INC

Fixes: https://rt.cpan.org/Public/Bug/Display.html?id=120709