### PR TITLE
Fix compilation against MySQL 8.0.1 header files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,8 @@ matrix:
     - perl: "5.20"
       env: DB=MySQL VERSION=8.0.0-dmr
     - perl: "5.20"
+      env: DB=MySQL VERSION=8.0.1-dmr
+    - perl: "5.20"
       env: DB=MariaDB VERSION=5.5.40
     - perl: "5.20"
       env: DB=MariaDB VERSION=5.5.44

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3337,7 +3337,7 @@ dbd_st_prepare_sv(
           bind->buffer_type=  MYSQL_TYPE_STRING;
           bind->buffer=       NULL;
           bind->length=       &(fbind->length);
-          bind->is_null=      (char*) &(fbind->is_null);
+          bind->is_null=      &(fbind->is_null);
           fbind->is_null=     1;
           fbind->length=      0;
         }
@@ -4162,7 +4162,7 @@ int dbd_describe(SV* sth, imp_sth_t* imp_sth)
       buffer->buffer_type= fields[i].type;
       buffer->is_unsigned= (fields[i].flags & UNSIGNED_FLAG) ? 1 : 0;
       buffer->length= &(fbh->length);
-      buffer->is_null= (my_bool*) &(fbh->is_null);
+      buffer->is_null= &(fbh->is_null);
 #if MYSQL_VERSION_ID >= NEW_DATATYPE_VERSION
       buffer->error= (my_bool*) &(fbh->error);
 #endif

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -88,6 +88,10 @@
 #define mysql_warning_count(svsock) 0
 #endif
 
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 80001
+#define my_bool bool
+#endif
+
 #define true 1
 #define false 0
 

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -290,7 +290,7 @@ typedef union numeric_val_u {
 typedef struct imp_sth_phb_st {
     numeric_val_t   numeric_val;
     unsigned long   length;
-    char            is_null;
+    my_bool         is_null;
 } imp_sth_phb_t;
 
 /*
@@ -299,7 +299,7 @@ typedef struct imp_sth_phb_st {
  */
 typedef struct imp_sth_fbh_st {
     unsigned long  length;
-    bool           is_null;
+    my_bool        is_null;
     bool           error;
     char           *data;
     int            charsetnr;
@@ -312,7 +312,7 @@ typedef struct imp_sth_fbh_st {
 
 typedef struct imp_sth_fbind_st {
    unsigned long   * length;
-   char            * is_null;
+   my_bool         * is_null;
 } imp_sth_fbind_t;
 
 


### PR DESCRIPTION
The my_bool type is no longer used and defined by MySQL header files.