### PR TITLE
Make mysql_async_ready() and mysql_async_result() idempotent

### DIFF
--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -855,7 +855,7 @@ package DBD::mysql::st; # ====== STATEMENT ======
 use strict;
 
 BEGIN {
-    my @needs_async_result = qw/fetchrow_hashref fetchall_hashref/;
+    my @needs_async_result = qw/fetchrow_arrayref fetchrow_array fetchrow_hashref fetchall_arrayref fetchall_hashref/;
     my @needs_async_check = qw/bind_param_array bind_col bind_columns execute_for_fetch/;
 
     foreach my $method (@needs_async_result) {

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -2099,7 +2099,8 @@ C<mysql_async_result>, C<mysql_async_ready>, and C<mysql_fd>.
 C<mysql_async_result> returns what do or execute would have; that is, the
 number of rows affected.  C<mysql_async_ready> returns true if
 C<mysql_async_result> will not block, and zero otherwise.  They both return
-C<undef> if that handle is not currently running an asynchronous query.
+C<undef> if that handle was not created with 'async' set to true
+or if an asynchronous query was not started yet.
 C<mysql_fd> returns the file descriptor number for the MySQL connection; you
 can use this in an event loop.
 

--- a/t/89async-method-check.t
+++ b/t/89async-method-check.t
@@ -81,7 +81,7 @@ plan tests =>
   2 * @db_safe_methods     +
   4 * @db_unsafe_methods   +
   7 * @st_safe_methods     +
-  2 * @common_safe_methods +
+  3 * @common_safe_methods +
   2 * @st_unsafe_methods   +
   3;
 
@@ -119,6 +119,7 @@ foreach my $method (@common_safe_methods) {
     $sth->$method(@$args);
     ok !$sth->errstr, "Testing method '$method' on DBD::mysql::db during asynchronous operation";
     ok defined($sth->mysql_async_result);
+    ok defined($sth->mysql_async_result);
 }
 
 foreach my $method (@st_safe_methods) {
@@ -128,9 +129,9 @@ foreach my $method (@st_safe_methods) {
     $sth->$method(@$args);
     ok !$sth->errstr, "Testing method '$method' on DBD::mysql::st during asynchronous operation";
 
-    # statement safe methods clear async state
-    ok !defined($sth->mysql_async_result), "Testing DBD::mysql::st method '$method' clears async state";
-    like $sth->errstr, qr/Gathering asynchronous results for a synchronous handle/;
+    # statement safe methods cache async result and mysql_async_result can be called multiple times
+    ok defined($sth->mysql_async_result), "Testing DBD::mysql::st method '$method' for async result";
+    ok defined($sth->mysql_async_result), "Testing DBD::mysql::st method '$method' for async result";
 }
 
 foreach my $method (@st_safe_methods) {


### PR DESCRIPTION
`$sth->mysql_async_ready` now returns 1 also after `$sth->mysql_async_result`. And duplicate `$sth->mysql_async_result` now returns same value (repeated time just cached value, instead throwing error).
    
This change would allow to call `$sth->mysql_async_result` more times without changing internal state or throwing errors.

And afterword it allow to call `$sth->mysql_async_ready` and `$sth->mysql_async_result` before all fetch* $sth methods which fixes bugs:

https://rt.cpan.org/Public/Bug/Display.html?id=103306
https://github.com/jhthorsen/mojo-mysql/issues/1

Note that it changes behavior of both `mysql_async_ready` and `mysql_async_result` methods. Before this change both methods returned `undef` if corresponding handle was not currently running an asynchronous query. After this change both methods return `undef` if corresponding handle was not created with 'async' set to true or if an asynchronous query was not started yet.