### PR TITLE
Added skip logic for unsupported MySQL Server versions

### DIFF
--- a/t/10connect.t
+++ b/t/10connect.t
@@ -41,13 +41,26 @@ like(
 
 like($driver_ver, qr/^04\./, 'SQL_DRIVER_VER starts with "04." (update for 5.x)');
 
-# storage engine function is @@storage_engine in up to 5.5.03
-# at that version, @@default_storage_engine is introduced
+# The variable name for MySQL's storage engine function has varied over time
+#
+# From MySQL version 3.23.0 until 4.1.2: @@table_type
+#   removed in 5.5.0
+# https://downloads.mysql.com/docs/refman-4.1-en.a4.pdf
+#
+# From MySQL version 4.1.2 until 5.5.3: @@storage_engine
+#   removed in 5.7.5
 # http://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html#sysvar_storage_engine
-# in MySQL Server 5.7.5 the old option is removed
+#
+# From MySQL version 5.5.3:  @@default_storage_engine
 # http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_storage_engine
 
-my $storage_engine = $dbh->{mysql_serverversion} >= 50503 ? '@@default_storage_engine' : '@@storage_engine';
+my $storage_engine = '@@default_storage_engine';
+if ($dbh->{mysql_serverversion} < 50503) {
+    $storage_engine = '@@storage_engine';
+} elsif ($dbh->{mysql_serverversion} < 40102) {
+    $storage_engine = '@@table_type';
+}
+
 my $result = $dbh->selectall_arrayref('select ' . $storage_engine);
 my $default_storage_engine = $result->[0]->[0] || 'unknown';
 diag "Default storage engine is: $default_storage_engine";

--- a/t/55utf8_jp.t
+++ b/t/55utf8_jp.t
@@ -11,6 +11,11 @@ require "lib.pl";
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { mysql_enable_utf8 => 1, PrintError => 1, RaiseError => 1 });
 
+if (!MinimumVersion($dbh, '5.5')) {
+    plan skip_all =>
+        "SKIP TEST: You must have MySQL version 5.5 or greater for this test to run";
+}
+
 eval {
   $dbh->{PrintError} = 0;
   $dbh->do("SET lc_messages = 'ja_JP'");

--- a/t/cve-2017-3302.t
+++ b/t/cve-2017-3302.t
@@ -1,4 +1,10 @@
 # This must be minimal test, even strict or Test::More can hide real crash
+# This test should be restricted to affected versions:
+#   MySQL   <= 5.7.5
+#   MariaDB <= 5.5.54
+#   MariaDB <= 10.0.29
+#   MariaDB <= 10.1.21
+#   MariaDB <= 10.2.3
 if ($ENV{SKIP_CRASH_TESTING}) {
   print "1..0 # SKIP \$ENV{SKIP_CRASH_TESTING} is set\n";
   exit;
@@ -9,7 +15,7 @@ use vars qw($test_dsn $test_user $test_password $test_db);
 use lib 't', '.';
 require "lib.pl";
 eval {
-  $dbh = DBI->connect($test_dsn, $test_user, $test_password, {RaiseError => 1, mysql_server_prepare => 1});
+  $dbh = DBI->connect($test_dsn, $test_user, $test_password, {RaiseError => 1});
 } or do {
   $@ = "unknown error" unless $@;
   $@ =~ s/ at \S+ line \d+\s*$//;

--- a/t/magic.t
+++ b/t/magic.t
@@ -14,6 +14,10 @@ binmode $tb->todo_output,    ":utf8";
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 0, mysql_server_prepare_disable_fallback => 1 });
 
+if (!MinimumVersion($dbh, '4.1')) {
+    plan skip_all =>
+        "SKIP TEST: You must have MySQL version 4.1 or greater for this test to run"
+}
 plan tests => 288*2;
 
 $dbh->do("CREATE TEMPORARY TABLE t(i INT)");

--- a/t/rt118977-zerofill.t
+++ b/t/rt118977-zerofill.t
@@ -13,6 +13,9 @@ my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 
 plan tests => 4*2;
 
 for my $mysql_server_prepare (0, 1) {
+SKIP: {
+	skip 'SKIP TEST: You must have MySQL version 4.1 and greater for this test to run', 4
+		if !MinimumVersion($dbh, '4.1') && $mysql_server_prepare == 1;
 
 	$dbh->{mysql_server_prepare} = $mysql_server_prepare;
 
@@ -20,5 +23,5 @@ for my $mysql_server_prepare (0, 1) {
 	ok $dbh->do("CREATE TEMPORARY TABLE t(id smallint(5) unsigned zerofill)");
 	ok $dbh->do("INSERT INTO t(id) VALUES(1)");
 	is $dbh->selectcol_arrayref("SELECT id FROM t")->[0], "00001";
-
+}
 }


### PR DESCRIPTION
Added logic to skip tests when they are ran against a version of MySQL that doesn't support the feature being tested.