### PR TITLE
Added socket.o to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ mysql.bs
 mysql.c
 mysql.o
 mysql.xsi
+socket.o
 pm_to_blib
 t/mysql.mtest
 MYMETA.*


### PR DESCRIPTION
This file was generated when I ran `make` and it should be excluded from the repository.