### PR TITLE
Revert test edits

### DIFF
--- a/t/10connect.t
+++ b/t/10connect.t
@@ -55,10 +55,10 @@ like($driver_ver, qr/^04\./, 'SQL_DRIVER_VER starts with "04." (update for 5.x)'
 # http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_storage_engine
 
 my $storage_engine = '@@default_storage_engine';
-if ($dbh->{mysql_serverversion} < 50503) {
-    $storage_engine = '@@storage_engine';
-} elsif ($dbh->{mysql_serverversion} < 40102) {
+if ($dbh->{mysql_serverversion} < 40102) {
     $storage_engine = '@@table_type';
+} elsif ($dbh->{mysql_serverversion} < 50503) {
+    $storage_engine = '@@storage_engine';
 }
 
 my $result = $dbh->selectall_arrayref('select ' . $storage_engine);

--- a/t/55utf8_jp.t
+++ b/t/55utf8_jp.t
@@ -11,11 +11,6 @@ require "lib.pl";
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { mysql_enable_utf8 => 1, PrintError => 1, RaiseError => 1 });
 
-if (!MinimumVersion($dbh, '5.5')) {
-    plan skip_all =>
-        "SKIP TEST: You must have MySQL version 5.5 or greater for this test to run";
-}
-
 eval {
   $dbh->{PrintError} = 0;
   $dbh->do("SET lc_messages = 'ja_JP'");

--- a/t/cve-2017-3302.t
+++ b/t/cve-2017-3302.t
@@ -10,9 +10,10 @@ use lib 't', '.';
 require "lib.pl";
 eval {
   $dbh = DBI->connect($test_dsn, $test_user, $test_password, {RaiseError => 1, mysql_server_prepare => 1});
+  die 'MySQL version less than 4.1 does not support prepared statements' unless MinimumVersion($dbh, '4.1');
 } or do {
   $@ = "unknown error" unless $@;
-  $@ =~ s/ at \S+ line \d+\s*$//;
+  $@ =~ s/ at \S+ line \d+\.?\s*$//;
   print(($ENV{CONNECTION_TESTING} ? "Bail out!  " : "1..0 # SKIP ") . "no database connection: $@\n");
   exit($ENV{CONNECTION_TESTING} ? 255 : 0);
 };

--- a/t/cve-2017-3302.t
+++ b/t/cve-2017-3302.t
@@ -10,7 +10,7 @@ use lib 't', '.';
 require "lib.pl";
 eval {
   $dbh = DBI->connect($test_dsn, $test_user, $test_password, {RaiseError => 1, mysql_server_prepare => 1});
-  die 'MySQL version less than 4.1 does not support prepared statements' unless MinimumVersion($dbh, '4.1');
+  die 'MySQL version less than 4.1.3 does not support prepared statements' unless $dbh->{mysql_serverversion} >= 40103 && $dbh->{mysql_clientversion} >= 40103;
 } or do {
   $@ = "unknown error" unless $@;
   $@ =~ s/ at \S+ line \d+\.?\s*$//;

--- a/t/cve-2017-3302.t
+++ b/t/cve-2017-3302.t
@@ -1,10 +1,4 @@
 # This must be minimal test, even strict or Test::More can hide real crash
-# This test should be restricted to affected versions:
-#   MySQL   <= 5.7.5
-#   MariaDB <= 5.5.54
-#   MariaDB <= 10.0.29
-#   MariaDB <= 10.1.21
-#   MariaDB <= 10.2.3
 if ($ENV{SKIP_CRASH_TESTING}) {
   print "1..0 # SKIP \$ENV{SKIP_CRASH_TESTING} is set\n";
   exit;
@@ -15,7 +9,7 @@ use vars qw($test_dsn $test_user $test_password $test_db);
 use lib 't', '.';
 require "lib.pl";
 eval {
-  $dbh = DBI->connect($test_dsn, $test_user, $test_password, {RaiseError => 1});
+  $dbh = DBI->connect($test_dsn, $test_user, $test_password, {RaiseError => 1, mysql_server_prepare => 1});
 } or do {
   $@ = "unknown error" unless $@;
   $@ =~ s/ at \S+ line \d+\s*$//;


### PR DESCRIPTION
Reverted the edits made in `t/cve-2017-3302.t` as per @pali's request.

Changed logic to check minimum server version? @pali not sure if that is OK or not. If not, I'll remove the extra check.

Fixed if logic in `t/10connect.t` as it checked version number in the wrong order.