### PR TITLE
Fix detection of INNODB engine in tests

### DIFF
--- a/t/40catalog.t
+++ b/t/40catalog.t
@@ -31,7 +31,7 @@ SKIP: {
     if !MinimumVersion($dbh, '5.0');
 
   my $have_innodb = 0;
-  if (!MinimumVersion($dbh, '5.6')) {
+  if (!MinimumVersion($dbh, '4.1.2')) {
     my $dummy;
     ($dummy,$have_innodb)=
       $dbh->selectrow_array("SHOW VARIABLES LIKE 'have_innodb'")

--- a/t/rt75353-innodb-lock-timeout.t
+++ b/t/rt75353-innodb-lock-timeout.t
@@ -18,7 +18,7 @@ if (!@ilwtenabled) {
 }
 
 my $have_innodb = 0;
-if (!MinimumVersion($dbh1, '5.6')) {
+if (!MinimumVersion($dbh1, '4.1.2')) {
   my $dummy;
   ($dummy,$have_innodb)=
     $dbh1->selectrow_array("SHOW VARIABLES LIKE 'have_innodb'")


### PR DESCRIPTION
When connecting to MariaDB server 10.1.x via MySQL client 5.5 then MySQL
client get information that server version is 5.5.5.

Variable have_innodb was removed in MySQL server 5.6 and is also not
available in MariaDB server 10.1. So INNODB engine is not detected.

So when possible use SHOW ENGINES which is supported since MySQL 4.1.2.