### PR TITLE
Revert "Call $sth->mysql_async_ready and $sth->mysql_async_result for all fetch* $sth methods"

### DIFF
--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -855,7 +855,7 @@ package DBD::mysql::st; # ====== STATEMENT ======
 use strict;
 
 BEGIN {
-    my @needs_async_result = qw/fetchrow_arrayref fetchrow_array fetchrow_hashref fetchall_arrayref fetchall_hashref/;
+    my @needs_async_result = qw/fetchrow_hashref fetchall_hashref/;
     my @needs_async_check = qw/bind_param_array bind_col bind_columns execute_for_fetch/;
 
     foreach my $method (@needs_async_result) {


### PR DESCRIPTION
This reverts commit 8acbd19567667195ea087b7ae4512a0bf5965f6a.

DBD::mysql already provides own fetchrow_arrayref(), fetchrow_array() and
fetchall_arrayref() methods implemented in C/XS which already internally
calls mysql_async_ready() and mysql_async_result().

That commit 8acbd19567667195ea087b7ae4512a0bf5965f6a just overwritten XS
implementation and under new Perl version also notified it by warnings:

Subroutine DBD::mysql::st::fetchrow_arrayref redefined
Subroutine DBD::mysql::st::fetchrow_array redefined
Subroutine DBD::mysql::st::fetchall_arrayref redefined

Bugs are already handled in commit d6a321088486af5a4364b78b8c8e931ac6136e0a.