### PR TITLE
ChopBlanks should not trim binary fields

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4240,6 +4240,11 @@ process:
         STRLEN len= lengths[i];
         if (ChopBlanks)
         {
+#if MYSQL_VERSION_ID >= FIELD_CHARSETNR_VERSION
+          if (fields[i].charsetnr != 63)
+#else
+          if (!(fields[i].flags & BINARY_FLAG))
+#endif
           while (len && col[len-1] == ' ')
           {	--len; }
         }

--- a/t/50chopblanks.t
+++ b/t/50chopblanks.t
@@ -14,7 +14,8 @@ eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
 if ($@) {
     plan skip_all => "no database connection";
 }
-plan tests => 36 * 2;
+
+plan tests => (8 + ((5 + 9 + 9) * 4)) * 2;
 
 for my $mysql_server_prepare (0, 1) {
 eval {$dbh= DBI->connect("$test_dsn;mysql_server_prepare=$mysql_server_prepare;mysql_server_prepare_disable_fallback=1", $test_user, $test_password,
@@ -25,42 +26,58 @@ ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t50chopblanks"), "drop table if exis
 my $create= <<EOT;
 CREATE TABLE dbd_mysql_t50chopblanks (
   id INT(4),
-  name VARCHAR(64)
+  c_varchar VARCHAR(64),
+  c_text TEXT,
+  c_tinytext TINYTEXT,
+  c_mediumtext MEDIUMTEXT,
+  c_longtext LONGTEXT,
+  b_blob BLOB,
+  b_tinyblob TINYBLOB,
+  b_mediumblob MEDIUMBLOB,
+  b_longblob LONGBLOB
 )
 EOT
 
 ok $dbh->do($create), "create table dbd_mysql_t50chopblanks";
 
-ok (my $sth= $dbh->prepare("INSERT INTO dbd_mysql_t50chopblanks (id, name) VALUES (?, ?)"));
+my @fields = qw(c_varchar c_text c_tinytext c_mediumtext c_longtext b_blob b_tinyblob b_mediumblob b_longblob);
+my $numfields = scalar @fields;
+my $fieldlist = join(', ', @fields);
 
-ok (my $sth2= $dbh->prepare("SELECT id, name FROM dbd_mysql_t50chopblanks WHERE id = ?"));
+ok (my $sth= $dbh->prepare("INSERT INTO dbd_mysql_t50chopblanks (id, $fieldlist) VALUES (".('?, ' x $numfields)."?)"));
+
+ok (my $sth2= $dbh->prepare("SELECT $fieldlist FROM dbd_mysql_t50chopblanks WHERE id = ?"));
 
 my $rows;
 
 $rows = [ [1, ''], [2, ' '], [3, ' a b c '], [4, 'blah'] ];
 
 for my $ref (@$rows) {
-	my ($id, $name) = @$ref;
-        ok $sth->execute($id, $name), "insert into dbd_mysql_t50chopblanks values ($id, '$name')";
-	ok $sth2->execute($id), "select id, name from dbd_mysql_t50chopblanks where id = $id";
+	my ($id, $value) = @$ref;
+	ok $sth->execute($id, ($value) x $numfields), "insert into dbd_mysql_t50chopblanks values ($id ".(", '$value'" x $numfields).")";
+	ok $sth2->execute($id), "select $fieldlist from dbd_mysql_t50chopblanks where id = $id";
 
 	# First try to retrieve without chopping blanks.
 	$sth2->{'ChopBlanks'} = 0;
-        my $ret_ref = [];
+	my $ret_ref = [];
 	ok ($ret_ref = $sth2->fetchrow_arrayref);
-	cmp_ok $ret_ref->[1], 'eq', $name, "\$name should not have blanks chopped";
+	for my $i (0 .. $#{$ret_ref}) {
+		cmp_ok $ret_ref->[$i], 'eq', $value, "NoChopBlanks: $fields[$i] should not have blanks chopped";
+	}
 
 	# Now try to retrieve with chopping blanks.
 	$sth2->{'ChopBlanks'} = 1;
 
 	ok $sth2->execute($id);
 
-	my $n = $name;
-	$n =~ s/\s+$//;
-        $ret_ref = [];
+	$ret_ref = [];
 	ok ($ret_ref = $sth2->fetchrow_arrayref);
-
-	cmp_ok $ret_ref->[1], 'eq', $n, "should have blanks chopped";
+	for my $i (0 .. $#{$ret_ref}) {
+		my $choppedvalue = $value;
+		my $character_field = ($fields[$i] =~ /^c/);
+		$choppedvalue =~ s/\s+$// if $character_field; # only chop character, not binary
+		cmp_ok $ret_ref->[$i], 'eq', $choppedvalue, "ChopBlanks: $fields[$i] should ".($character_field ? "" : "not ")."have blanks chopped";
+	}
 
 }
 ok $sth->finish;


### PR DESCRIPTION
Binary fields are incorrectly being trimmed of trailing spaces when non server side prepare is being used.
Trimming of server side prepare binary fields is catered for properly.

"As of MySQL 5.0.3, trailing spaces are retained when values are stored and retrieved, in conformance with standard SQL. Before MySQL 5.0.3, trailing spaces are removed from values when they are stored into a VARCHAR column; this means that the spaces also are absent from retrieved values."

This means that testing VARCHAR (and VARBINARY as it turns out) on 4.1.22 will cause the test cases to fail.
However, since we're testing BLOB, TINYBLOB, MEDIUMBLOB and LONGBLOB, we have enough binary fields to confirm that after the change we do not trim the trailing spaces from binary fields after retrieval on the client side.