### PR TITLE
Fix use-after-free after calling mysql_stmt_close()

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4446,12 +4446,8 @@ void dbd_st_destroy(SV *sth, imp_sth_t *imp_sth) {
 
   if (imp_sth->stmt)
   {
-    if (mysql_stmt_close(imp_sth->stmt))
-    {
-      do_error(DBIc_PARENT_H(imp_sth), mysql_stmt_errno(imp_sth->stmt),
-          mysql_stmt_error(imp_sth->stmt),
-          mysql_stmt_sqlstate(imp_sth->stmt));
-    }
+    mysql_stmt_close(imp_sth->stmt);
+    imp_sth->stmt= NULL;
   }
 #endif
 

--- a/mysql.xs
+++ b/mysql.xs
@@ -416,11 +416,8 @@ do(dbh, statement, attr=Nullsv, ...)
       if (bind)
         Safefree(bind);
 
-      if(mysql_stmt_close(stmt))
-      {
-        fprintf(stderr, "\n failed while closing the statement");
-        fprintf(stderr, "\n %s", mysql_stmt_error(stmt));
-      }
+      mysql_stmt_close(stmt);
+      stmt= NULL;
 
       if (retval == -2) /* -2 means error */
       {


### PR DESCRIPTION
Ignore return value from mysql_stmt_close() and also its error message
because it points to freed memory after mysql_stmt_close() was called.

Closes: #120