### PR TITLE
appveyor: use gmake instead of dmake

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ build_script:
   - perl Makefile.PL --mysql_config=c:\strawberry\c\bin\mysql_config.bat --testuser=root --testpassword=Password12!
 
 test_script:
-  - dmake test
+  - gmake test


### PR DESCRIPTION
Fixes appveyor test issue

    Writing MYMETA.yml and MYMETA.json
    dmake test
    #############################################################
    ###                                                       ###
    ###                     DMAKE WARNING                     ###
    ###                                                       ###
    ###  Do not use dmake.exe utility as it is no longer      ###
    ###  part of Strawberry Perl, use gmake.exe instead!      ###
    ###                                                       ###
    ###  If you have troubles with CPAN client delete:        ###
    ###  %USERPROFILE%\AppData\Local\.cpan\CPAN\MyConfig.pm   ###
    ###                                                       ###
    #############################################################
    Command exited with code 1