### PR TITLE
Upgrade Makefile.PL to meta-spec 2, github issues

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -376,12 +376,19 @@ if (eval $ExtUtils::MakeMaker::VERSION >= 5.43) {
     LICENSE => 'perl',
     MIN_PERL_VERSION => '5.008001',
     META_MERGE => {
+      'meta-spec' => { version => 2 },
+      dynamic_config => 0,
       resources => {
-        repository => 'https://github.com/perl5-dbi/DBD-mysql',
-        MailingList => 'mailto:dbi-dev@perl.org',
-        license     => 'http://dev.perl.org/licenses/',
-        homepage    => 'http://dbi.perl.org/',
-        IRC         => 'irc://irc.perl.org/#dbi',
+        repository => {
+          type => 'git',
+          url  => 'https://github.com/perl5-dbi/DBD-mysql.git',
+          web  => 'https://github.com/perl5-dbi/DBD-mysql',
+        },
+        bugtracker    => { web => 'https://github.com/perl5-dbi/DBD-mysql/issues' },
+        x_MailingList => 'mailto:dbi-dev@perl.org',
+        license       => ['http://dev.perl.org/licenses/'],
+        homepage      => 'http://dbi.perl.org/',
+        x_IRC         => 'irc://irc.perl.org/#dbi',
       },
       x_contributors => [
         # a list of our awesome contributors generated from git


### PR DESCRIPTION
This updates the META_MERGE section in Makefile.PL to use the current meta-spec version 2, adds bugtracker metadata so github will be considered the canonical issue tracker, and sets dynamic_config to 0 since Makefile.PL does not set prereqs dynamically (this is only appropriate for meta-spec 2 - https://metacpan.org/pod/CPAN::Meta::Spec#dynamic_config).

I've verified that in the generated META.json this only adds more specific repository metadata, adds the bugtracker metadata, and sets dynamic_config to 0.