### PR TITLE
Allow testsuite to run against 8.0.3

### DIFF
--- a/t/rt50304-column_info_parentheses.t
+++ b/t/rt50304-column_info_parentheses.t
@@ -15,6 +15,11 @@ if ($@) {
     plan skip_all => "no database connection";
 }
 
+if (($dbh->{'mysql_serverversion'} >= 80000) && ($dbh->{'mysql_serverversion'} < 90000)) {
+    plan skip_all =>
+        "MySQL 8.0 is affected by Bug #89224";
+}
+
 my $create = <<EOC;
 CREATE TEMPORARY TABLE dbd_mysql_rt50304_column_info (
     id int(10)unsigned NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
Two issues:

1. `AsBinary` and `GeomFromText` are gone in 8.0. Use `ST_AsBinary` and `ST_GeomFromTest` instead.
2. MySQL 8.0.3 returns too many rows for `DESCRIBE` with a column specification

https://bugs.mysql.com/bug.php?id=89224