### PR TITLE
Use API function for reconnect

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2104,6 +2104,16 @@ MYSQL *mysql_dr_connect(
 
     if (result)
     {
+      /*
+        we turn off Mysql's auto reconnect and handle re-connecting ourselves
+        so that we can keep track of when this happens.
+      */
+#if MYSQL_VERSION_ID >= 50013
+      my_bool reconnect = FALSE;
+      mysql_options(result, MYSQL_OPT_RECONNECT, &reconnect);
+#else
+      result->reconnect = 0;
+#endif
 #if MYSQL_VERSION_ID >=SERVER_PREPARE_VERSION
       /* connection succeeded. */
       /* imp_dbh == NULL when mysql_dr_connect() is called from mysql.xs
@@ -2117,12 +2127,6 @@ MYSQL *mysql_dr_connect(
           imp_dbh->async_query_in_flight = NULL;
       }
 #endif
-
-      /*
-        we turn off Mysql's auto reconnect and handle re-connecting ourselves
-        so that we can keep track of when this happens.
-      */
-      result->reconnect=0;
     }
     else {
       /* 


### PR DESCRIPTION
For configuring reconnect functionality use standard API function
MYSQL_OPT_RECONNECT instead of direct modification of internal structures
which does not work for MariaDB. Fixes compilation with MariaDB 10.2.6+.

Source: https://github.com/gooddata/DBD-MariaDB/commit/9cfed385af6c437e87e981022eef440cc2d99777