### PR TITLE
Remove #IFDEFs for detecting ancient DBI versions

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,6 @@
 2018-02-?? Patrick Galbraith, Michiel Beijen, DBI/DBD community (4.046_01)
+* Remove #IFDEFs for code detecting ancient DBI versions. The minimum
+  DBI version we require is version 1.609 from 2009!
 * ChopBlanks should not trim binary fields (urcheon)
 * Skipped test which failed on OpenBSD because Proc::ProcessTable does not
   come with a 'size' attribute on this platform (glasswalk3r, pali)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -248,7 +248,6 @@ if ($^O eq 'VMS') {
   $cflags = "\$(DBI_INSTARCH_DIR),$opt->{'cflags'}";
 }
 $cflags .= " -DDBD_MYSQL_WITH_SSL" if !$opt->{'nossl'};
-$cflags .= " -DDBD_MYSQL_INSERT_ID_IS_GOOD" if $DBI::VERSION > 1.42;
 $cflags .= " -DDBD_MYSQL_NO_CLIENT_FOUND_ROWS" if $opt->{'nofoundrows'};
 $cflags .= " -g ";
 my %o = ( 'NAME' => 'DBD::mysql',

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5482,7 +5482,6 @@ SV* dbd_db_quote(SV *dbh, SV *str, SV *type)
   return result;
 }
 
-#ifdef DBD_MYSQL_INSERT_ID_IS_GOOD
 SV *mysql_db_last_insert_id(SV *dbh, imp_dbh_t *imp_dbh,
         SV *catalog, SV *schema, SV *table, SV *field, SV *attr)
 {
@@ -5499,7 +5498,6 @@ SV *mysql_db_last_insert_id(SV *dbh, imp_dbh_t *imp_dbh,
   ASYNC_CHECK_RETURN(dbh, &PL_sv_undef);
   return sv_2mortal(my_ulonglong2str(aTHX_ mysql_insert_id(imp_dbh->pmysql)));
 }
-#endif
 
 #if MYSQL_ASYNC
 int mysql_db_async_result(SV* h, MYSQL_RES** resp)

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -375,10 +375,7 @@ struct imp_sth_st {
 #define do_error		mysql_dr_error
 #define dbd_db_type_info_all    mysql_db_type_info_all
 #define dbd_db_quote            mysql_db_quote
-
-#ifdef DBD_MYSQL_INSERT_ID_IS_GOOD /* prototype was broken in some versions of dbi */
 #define dbd_db_last_insert_id   mysql_db_last_insert_id
-#endif
 
 #include <dbd_xsh.h>
 void    do_error (SV* h, int rc, const char *what, const char *sqlstate);

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -144,11 +144,8 @@ sub connect {
 				    ['database', 'host', 'port']);
 
 
-    if ($DBI::VERSION >= 1.49)
-    {
-      $dbi_imp_data = delete $attrhash->{dbi_imp_data};
-      $connect_ref->{'dbi_imp_data'} = $dbi_imp_data;
-    }
+    $dbi_imp_data = delete $attrhash->{dbi_imp_data};
+    $connect_ref->{'dbi_imp_data'} = $dbi_imp_data;
 
     if (!defined($this = DBI::_new_dbh($drh,
             $connect_ref,

--- a/t/70takeimp.t
+++ b/t/70takeimp.t
@@ -22,12 +22,6 @@ eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
 if ($@) {
     plan skip_all => "no database connection";
 }
-unless ($DBI::VERSION ge '1.607') {
-    plan skip_all => "version of DBI $DBI::VERSION doesn't support this test. Can't continue test";
-}
-unless ($dbh->can('take_imp_data')) {
-    plan skip_all => "version of DBI $DBI::VERSION doesn't support this test. Can't continue test";
-}
 plan tests => 21;
 
 pass("obtained driver handle");

--- a/t/71impdata.t
+++ b/t/71impdata.t
@@ -25,12 +25,6 @@ if (! defined $drh) {
     plan skip_all => "Can't obtain driver handle. Can't continue test";
 }
 
-unless ($DBI::VERSION ge '1.607') {
-    plan skip_all => "version of DBI $DBI::VERSION doesn't support this test. Can't continue test";
-}
-unless ($dbh->can('take_imp_data')) {
-    plan skip_all => "version of DBI $DBI::VERSION doesn't support this test. Can't continue test";
-}
 plan tests => 10;
 
 pass("Connected to database");


### PR DESCRIPTION
 The minimum DBI version we require is version 1.609 from 2009!