### PR TITLE
Always compile enable_utf8 and remove ifdef checks for sv_utf8_decode…

### DIFF
--- a/dbdimp.h
+++ b/dbdimp.h
@@ -237,10 +237,8 @@ struct imp_dbh_st {
 #if MYSQL_ASYNC
     void* async_query_in_flight;
 #endif
-#if defined(sv_utf8_decode) && MYSQL_VERSION_ID >=SERVER_PREPARE_VERSION
     bool enable_utf8;
     bool enable_utf8mb4;
-#endif
     struct {
 	    unsigned int auto_reconnects_ok;
 	    unsigned int auto_reconnects_failed;


### PR DESCRIPTION
… and SvUTF8

Boolean variables enable_utf8 and enable_utf8mb4 are needed for UTF-8
support. Macros sv_utf8_decode and SvUTF8 are part of perl 5.6.0 and
DBD::mysql already needs at least perl 5.8.1.