### PR TITLE
Fix GCC 8.1 warnings

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3160,7 +3160,7 @@ dbd_st_prepare(
           bind->buffer_type=  MYSQL_TYPE_STRING;
           bind->buffer=       NULL;
           bind->length=       &(fbind->length);
-          bind->is_null=      (char*) &(fbind->is_null);
+          bind->is_null=      (_Bool*) &(fbind->is_null);
           fbind->is_null=     1;
           fbind->length=      0;
         }

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2015,7 +2015,7 @@ MYSQL *mysql_dr_connect(
     #endif
 
 	    if (ssl_verify) {
-          if (!ssl_verify_usable() && ssl_enforce && ssl_verify_set) {
+	      if (!ssl_verify_usable() && ssl_enforce && ssl_verify_set) {
 	        set_ssl_error(sock, "mysql_ssl_verify_server_cert=1 is broken by current version of MySQL client");
 	        return NULL;
 	      }

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1920,13 +1920,17 @@ MYSQL *mysql_dr_connect(
 	    STRLEN lna;
 	    unsigned int ssl_mode;
 	    my_bool ssl_verify = 0;
+  #if defined(HAVE_SSL_VERIFY)
 	    my_bool ssl_verify_set = 0;
+  #endif
 
             /* Verify if the hostname we connect to matches the hostname in the certificate */
 	    if ((svp = hv_fetch(hv, "mysql_ssl_verify_server_cert", 28, FALSE)) && *svp) {
+  #if defined(HAVE_SSL_VERIFY)
+	      ssl_verify_set = 1;
+  #endif
   #if defined(HAVE_SSL_VERIFY) || defined(HAVE_SSL_MODE)
 	      ssl_verify = SvTRUE(*svp);
-	      ssl_verify_set = 1;
   #else
 	      set_ssl_error(sock, "mysql_ssl_verify_server_cert=1 is not supported");
 	      return NULL;

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1932,8 +1932,8 @@ MYSQL *mysql_dr_connect(
 	      return NULL;
   #endif
 	    }
-        if ((svp = hv_fetch(hv, "mysql_ssl_optional", 18, FALSE)) && *svp)
-            ssl_enforce = !SvTRUE(*svp);
+	    if ((svp = hv_fetch(hv, "mysql_ssl_optional", 18, FALSE)) && *svp)
+	      ssl_enforce = !SvTRUE(*svp);
 
 	    if ((svp = hv_fetch(hv, "mysql_ssl_client_key", 20, FALSE)) && *svp)
 	      client_key = SvPV(*svp, lna);

--- a/mysql.xs
+++ b/mysql.xs
@@ -783,10 +783,6 @@ dbd_mysql_get_info(dbh, sql_info_type)
     D_imp_dbh(dbh);
     IV type = 0;
     SV* retsv=NULL;
-#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 50709
-/* MariaDB 10 is not MySQL source level compatible so this only applies to MySQL*/
-    IV buffer_len;
-#endif 
 
     if (SvMAGICAL(sql_info_type))
         mg_get(sql_info_type);


### PR DESCRIPTION
Fix compiler warnings with GCC 8.1.1
This is with compiling against MySQL 8.0.11.

Initial output:
```
$ make
cp lib/Bundle/DBD/mysql.pm blib/lib/Bundle/DBD/mysql.pm
cp lib/DBD/mysql.pm blib/lib/DBD/mysql.pm
cp lib/DBD/mysql/INSTALL.pod blib/lib/DBD/mysql/INSTALL.pod
Skip blib/lib/DBD/mysql/GetInfo.pm (unchanged)
Running Mkbootstrap for mysql ()
chmod 644 "mysql.bs"
"/usr/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- mysql.bs blib/arch/auto/DBD/mysql/mysql.bs 644
gcc -c  -I/usr/lib64/perl5/vendor_perl/auto/DBI -I/opt/mysql/8.0.11/include -DDBD_MYSQL_WITH_SSL -g  -D_REENTRANT -D_GNU_SOURCE -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -g   -DVERSION=\"4.046_01\" -DXS_VERSION=\"4.046_01\" -fPIC "-I/usr/lib64/perl5/CORE"   dbdimp.c
dbdimp.c: In function ‘mysql_dr_connect’:
dbdimp.c:1935:9: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
         if ((svp = hv_fetch(hv, "mysql_ssl_optional", 18, FALSE)) && *svp)
         ^~
dbdimp.c:1938:6: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
      if ((svp = hv_fetch(hv, "mysql_ssl_client_key", 20, FALSE)) && *svp)
      ^~
dbdimp.c:1923:14: warning: variable ‘ssl_verify_set’ set but not used [-Wunused-but-set-variable]
      my_bool ssl_verify_set = 0;
              ^~~~~~~~~~~~~~
dbdimp.c: In function ‘mysql_st_prepare’:
dbdimp.c:3159:24: warning: assignment to ‘_Bool *’ from incompatible pointer type ‘char *’ [-Wincompatible-pointer-types]
           bind->is_null=      (char*) &(fbind->is_null);
                        ^
"/usr/bin/perl" -p -e "s/~DRIVER~/mysql/g" /usr/lib64/perl5/vendor_perl/auto/DBI/Driver.xst > mysql.xsi
"/usr/bin/perl" "/usr/share/perl5/vendor_perl/ExtUtils/xsubpp"  -typemap '/usr/share/perl5/ExtUtils/typemap'  mysql.xs > mysql.xsc
Warning: duplicate function definition 'do' detected in mysql.xs, line 247
Warning: duplicate function definition 'rows' detected in mysql.xs, line 680
mv mysql.xsc mysql.c
gcc -c  -I/usr/lib64/perl5/vendor_perl/auto/DBI -I/opt/mysql/8.0.11/include -DDBD_MYSQL_WITH_SSL -g  -D_REENTRANT -D_GNU_SOURCE -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -g   -DVERSION=\"4.046_01\" -DXS_VERSION=\"4.046_01\" -fPIC "-I/usr/lib64/perl5/CORE"   mysql.c
mysql.c: In function ‘XS_DBD__mysql__GetInfo_dbd_mysql_get_info’:
mysql.xs:788:8: warning: unused variable ‘buffer_len’ [-Wunused-variable]
     IV buffer_len;
        ^~~~~~~~~~
gcc -c  -I/usr/lib64/perl5/vendor_perl/auto/DBI -I/opt/mysql/8.0.11/include -DDBD_MYSQL_WITH_SSL -g  -D_REENTRANT -D_GNU_SOURCE -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -g   -DVERSION=\"4.046_01\" -DXS_VERSION=\"4.046_01\" -fPIC "-I/usr/lib64/perl5/CORE"   socket.c
rm -f blib/arch/auto/DBD/mysql/mysql.so
gcc  -lpthread -shared -Wl,-z,relro -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -L/usr/local/lib -fstack-protector-strong  dbdimp.o mysql.o socket.o  -o blib/arch/auto/DBD/mysql/mysql.so  \
   -L/opt/mysql/8.0.11/lib -lmysqlclient -lpthread -lm -lrt -lssl -lcrypto -ldl -lperl   \
  
chmod 755 blib/arch/auto/DBD/mysql/mysql.so
Manifying 3 pod documents
[dvaneeden@dve-mac DBD-mysql]$ gcc --version
gcc (GCC) 8.1.1 20180712 (Red Hat 8.1.1-5)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

[dvaneeden@dve-mac DBD-mysql]$ git checkout -b gcc81_warnings
Switched to a new branch 'gcc81_warnings'
[dvaneeden@dve-mac DBD-mysql]$ vi dbdimp.c +1935
[dvaneeden@dve-mac DBD-mysql]$ vi dbdimp.c +1935
[dvaneeden@dve-mac DBD-mysql]$ make
"/usr/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- mysql.bs blib/arch/auto/DBD/mysql/mysql.bs 644
gcc -c  -I/usr/lib64/perl5/vendor_perl/auto/DBI -I/opt/mysql/8.0.11/include -DDBD_MYSQL_WITH_SSL -g  -D_REENTRANT -D_GNU_SOURCE -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -g   -DVERSION=\"4.046_01\" -DXS_VERSION=\"4.046_01\" -fPIC "-I/usr/lib64/perl5/CORE"   dbdimp.c
dbdimp.c: In function ‘mysql_dr_connect’:
dbdimp.c:1923:14: warning: variable ‘ssl_verify_set’ set but not used [-Wunused-but-set-variable]
      my_bool ssl_verify_set = 0;
              ^~~~~~~~~~~~~~
dbdimp.c: In function ‘mysql_st_prepare’:
dbdimp.c:3159:24: warning: assignment to ‘_Bool *’ from incompatible pointer type ‘char *’ [-Wincompatible-pointer-types]
           bind->is_null=      (char*) &(fbind->is_null);
                        ^
rm -f blib/arch/auto/DBD/mysql/mysql.so
gcc  -lpthread -shared -Wl,-z,relro -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -L/usr/local/lib -fstack-protector-strong  dbdimp.o mysql.o socket.o  -o blib/arch/auto/DBD/mysql/mysql.so  \
   -L/opt/mysql/8.0.11/lib -lmysqlclient -lpthread -lm -lrt -lssl -lcrypto -ldl -lperl   \
  
chmod 755 blib/arch/auto/DBD/mysql/mysql.so
Manifying 3 pod documents
```