### PR TITLE
Add options needed for public key based security.

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1907,6 +1907,21 @@ MYSQL *mysql_dr_connect(
                          (SvTRUE(*svp) ? "utf8" : "latin1"));
         }
 
+#if (MYSQL_VERSION_ID >= 50723) && (MYSQL_VERSION_ID < MARIADB_BASE_VERSION)
+        if ((svp = hv_fetch(hv, "mysql_get_server_pubkey", 23, FALSE)) && *svp && SvTRUE(*svp)) {
+          my_bool server_get_pubkey = 1;
+          mysql_options(sock, MYSQL_OPT_GET_SERVER_PUBLIC_KEY, &server_get_pubkey);
+        }
+#endif
+
+#if (MYSQL_VERSION_ID >= 50600) && (MYSQL_VERSION_ID < MARIADB_BASE_VERSION)
+        if ((svp = hv_fetch(hv, "mysql_server_pubkey", 19, FALSE)) && *svp) {
+          STRLEN plen;
+          char *server_pubkey = SvPV(*svp, plen);
+          mysql_options(sock, MYSQL_SERVER_PUBLIC_KEY, server_pubkey);
+        }
+#endif
+
 	if ((svp = hv_fetch(hv, "mysql_ssl", 9, FALSE)) && *svp && SvTRUE(*svp))
           {
 	    my_bool ssl_enforce = 1;

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1237,6 +1237,15 @@ connection to MySQL server if underlaying libmysqlclient library is
 vulnerable.  Option C<mysql_ssl_optional> can be used to make SSL
 connection vulnerable.
 
+=item mysql_server_pubkey
+
+Path to the RSA public key of the server. This is used for the
+sha256_password and caching_sha2_password authentication plugins.
+
+=item mysql_get_server_pubkey
+
+Setting C<mysql_get_server_pubkey> to true requests the public
+RSA key of the server.
 
 =item mysql_local_infile
 

--- a/t/01caching_sha2_prime.t
+++ b/t/01caching_sha2_prime.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+
+use Test::More ;
+use DBI;
+$|= 1;
+
+use vars qw($test_user $test_password $test_db $test_dsn);
+use lib 't', '.';
+require 'lib.pl';
+
+# remove database from DSN
+$test_dsn =~ s/^DBI:mysql:([^:]+)(:?)/DBI:mysql:$2/;
+
+# This should result in a cached sha2 password entry
+# The result is that subsequent connections don't need
+# TLS or the RSA pubkey.
+$test_dsn .= ';mysql_ssl=1;mysql_get_server_pubkey=1';
+
+my $dbh;
+eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
+                      { RaiseError => 1, PrintError => 1, AutoCommit => 0 });};
+if ($@) {
+    diag $@;
+    plan skip_all => "no database connection";
+}
+plan tests => 2;
+
+ok defined $dbh, "Connected to database";
+ok $dbh->disconnect();


### PR DESCRIPTION
This is used for the sha256_password and the caching_sha2_password
authentication plugins.

## Primary Target

Get DBD::mysql to work with MySQL 8.0 with default settings

This currently doesn't fully work because of the caching_sha2_password
plugin.

What works: Compiling and running with 8.0 client libs. Connections to MySQL 8.0
work if TLS is used or if the mysql_native_password plugin is used for
authentication.

## Secondary Target

Get DBD::mysql to work with the caching_sha2_password without the use
of TLS.

## Problem description

Official MySQL clients use TLS when available by default.
In DBD::mysql the default is to not use TLS.
If TLS is not used the caching_sha2_password needs RSA keys.
Before this commit DBD::mysql didn't have an option to either fetch the RSA key or specify a file.

The result is:
```
DBI connect('database=test;host=127.0.0.1;port=8011','msandbox2',...) failed: Authentication plugin 'caching_sha2_password' reported error: Authentication requires secure connection. at ./example.pl line 6.
```

## Testing

For testing you *must* test with and without the sha2 cache.
Use `FLUSH PRIVILEGES` to empty the sha2 cache.

## Fix

Add two options to DBD::mysql to
1. Enable fetching of the public key by setting the `MYSQL_OPT_GET_SERVER_PUBLIC_KEY` option
2. Enable specifying of the public key file by setting the `MYSQL_SERVER_PUBLIC_KEY` option

## Result

With this commit there are 3 options to connect to MySQL 8.0 with caching_sha2_password
1. Add `mysql_ssl=1` to the DSN (also working before this commit, requires a server with TLS enabled)
2. Add `mysql_get_server_pubkey=1` to the DSN
3. Add `mysql_server_pubkey=/path/to/public_key.pem` to the DSN

## Possible issues

1. Adding more tests might be needed
2. In all cases something needs to be added to the DSN. This can be fixed by setting `MYSQL_OPT_GET_SERVER_PUBLIC_KEY` to enabled by default, but that might be insecure.
3. According to the [docs](https://dev.mysql.com/doc/refman/5.7/en/mysql-options.html) this should work with 5.7.23 and newer. I tested only with 8.0.  The MYSQL_SERVER_PUBLIC_KEY is available in 5.6 and MariaDB.
4. The `MYSQL_OPT_GET_SERVER_PUBLIC_KEY` setting doesn't exist in MariaDB.