### PR TITLE
Remove MariaDB 10.3 from travis for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,8 +124,9 @@ matrix:
 #      env: DB=MariaDB VERSION=10.2.4
 #    - perl: "5.20"
 #      env: DB=MariaDB VERSION=10.2.5
-    - perl: "5.20"
-      env: DB=MariaDB VERSION=10.3.9
+# mariadb_config bug: https://jira.mariadb.org/browse/MDEV-15820
+#    - perl: "5.20"
+#      env: DB=MariaDB VERSION=10.3.9
     - perl: "5.20"
       env: CONC_DB=MySQL CONC_VERSION=6.0.0-beta
     - perl: "5.20"


### PR DESCRIPTION
mariadb_config (mysql_config for MariaDB) has a bug in 10.3
https://jira.mariadb.org/browse/MDEV-15820