### PR TITLE
MySQL 4.1 MYSQL_TYPE_BIT causes build failures

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2036,7 +2036,11 @@ MYSQL *mysql_dr_connect(
     #endif
 
 	    if (ssl_verify) {
+    #ifdef HAVE_SSL_VERIFY
 	      if (!ssl_verify_usable() && ssl_enforce && ssl_verify_set) {
+    #else
+	      if (!ssl_verify_usable() && ssl_enforce) {
+    #endif
 	        set_ssl_error(sock, "mysql_ssl_verify_server_cert=1 is broken by current version of MySQL client");
 	        return NULL;
 	      }

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -67,6 +67,11 @@
 #define my_bool bool
 #endif
 
+/* MYSQL_TYPE_BIT is not available on MySQL 4.1 */
+#ifndef MYSQL_TYPE_BIT
+#define MYSQL_TYPE_BIT 16
+#endif
+
 #define true 1
 #define false 0
 


### PR DESCRIPTION
This defines MYSQL_TYPE_BIT if not defined to fix build on 4.1.22

This is on top of #279