### PR TITLE
Make type of is_null field consistent and same as in MYSQL_BIND

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4027,7 +4027,7 @@ int dbd_describe(SV* sth, imp_sth_t* imp_sth)
         PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tmysql_to_perl_type returned %d\n",
                       col_type);
       buffer->length= &(fbh->length);
-      buffer->is_null= (my_bool*) &(fbh->is_null);
+      buffer->is_null= &(fbh->is_null);
 #if MYSQL_VERSION_ID >= NEW_DATATYPE_VERSION
       buffer->error= (my_bool*) &(fbh->error);
 #endif

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -260,7 +260,7 @@ typedef struct imp_sth_phb_st {
       double dval;
     } numeric_val;
     unsigned long   length;
-    char            is_null;
+    my_bool         is_null;
 } imp_sth_phb_t;
 
 /*
@@ -272,7 +272,7 @@ typedef struct imp_sth_phb_st {
  */
 typedef struct imp_sth_fbh_st {
     unsigned long  length;
-    bool           is_null;
+    my_bool        is_null;
     bool           error;
     char           *data;
     int            charsetnr;
@@ -286,7 +286,7 @@ typedef struct imp_sth_fbh_st {
 
 typedef struct imp_sth_fbind_st {
    unsigned long   * length;
-   char            * is_null;
+   my_bool         * is_null;
 } imp_sth_fbind_t;
 
 


### PR DESCRIPTION
This is a `git cherry-pick` 5cd65be3cca912dba90507f8bf10fd966b8a79ed because this seems to have gotten lost as part of 6fd72e55c9771b25b5775d08a120baae3181806e

Fixes compile warning: dbdimp.c:3340:24: warning: assignment from incompatible pointer type [enabled by default]