### PR TITLE
Fix quoting if NO_BACKSLASH_ESCAPES is set

### DIFF
--- a/t/17quote.t
+++ b/t/17quote.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+use vars qw($test_dsn $test_user $test_password);
+use lib '.', 't';
+require 'lib.pl';
+
+my $dbh;
+
+eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1}) or ServerError() ;};
+
+if ($@) {
+    plan skip_all => "no database connection";
+}
+
+my @sqlmodes = (qw/ empty ANSI_QUOTES NO_BACKSLASH_ESCAPES/);
+my @words = (qw/ foo foo'bar foo\bar /);
+my @results_empty = (qw/ 'foo' 'foo\'bar' 'foo\\\\bar'/);
+my @results_ansi = (qw/ 'foo' 'foo\'bar' 'foo\\\\bar'/);
+my @results_no_backlslash = (qw/ 'foo' 'foo''bar' 'foo\\bar'/);
+my @results = (\@results_empty, \@results_ansi, \@results_no_backlslash);
+
+plan tests => (@sqlmodes * @words * 2 + 1);
+
+while (my ($i, $sqlmode) = each @sqlmodes) {
+  $dbh->do("SET sql_mode=?", undef,  $sqlmode eq "empty" ? "" : $sqlmode);
+  for my $j (0..@words-1) {
+    ok $dbh->quote($words[$j]);
+    cmp_ok($dbh->quote($words[$j]), "eq", $results[$i][$j], "$sqlmode $words[$j]");
+  }
+}
+
+ok $dbh->disconnect;


### PR DESCRIPTION
`mysql_real_escape_string()` returns -1 if NO_BACKSLASH_ESCAPES sql mode is active.

The fix is to use  `mysql_real_escape_string_quote`

Also add more testing for quoting
