### PR TITLE
Implement statistics_info unique_only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ mysql.bs
 mysql.c
 mysql.o
 mysql.xsi
+socket.o
 pm_to_blib
 t/mysql.mtest
 MYMETA.*

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -755,6 +755,11 @@ EOF
         push @bind, $table;
     }
 
+    if ($unique_only) {
+        push @where, 'NON_UNIQUE = ?';
+        push @bind, 0;
+    }
+
     if (@where) {
         $sql .= ' WHERE ';
         $sql .= join ' AND ', @where;

--- a/t/40keyinfo.t
+++ b/t/40keyinfo.t
@@ -15,7 +15,6 @@ eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
 if ($@) {
     plan skip_all => "no database connection";
 }
-plan tests => 7;
 
 $dbh->{mysql_server_prepare}= 0;
 
@@ -42,6 +41,16 @@ is_deeply($key_info, $expect, "Check primary_key_info results");
 is_deeply([ $dbh->primary_key(undef, undef, 'dbd_mysql_keyinfo') ], [ 'a', 'b' ],
           "Check primary_key results");
 
+$sth= $dbh->statistics_info(undef, undef, 'dbd_mysql_keyinfo', 0, 0);
+my $stats_info = $sth->fetchall_arrayref;
+my $n_unique = grep $_->[3], @$stats_info;
+$sth= $dbh->statistics_info(undef, undef, 'dbd_mysql_keyinfo', 1, 0);
+$stats_info = $sth->fetchall_arrayref;
+my $n_unique2 = grep $_->[3], @$stats_info;
+isnt($n_unique2, $n_unique, "Check statistics_info unique_only flag has an effect");
+
 ok($dbh->do("DROP TABLE dbd_mysql_keyinfo"), "Dropped table");
 
 $dbh->disconnect();
+
+done_testing;


### PR DESCRIPTION
Currently `statistics_info` ignores the `$unique_only` only flag. This fixes that.