### PR TITLE
Fix type conversions

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4447,8 +4447,7 @@ process:
           if (!(fields[i].flags & ZEROFILL_FLAG))
           {
             /* Coerce to double and set scalar as NV */
-            (void) SvNV(sv);
-            SvNOK_only(sv);
+            sv_setnv(sv, SvNV(sv));
           }
           break;
 
@@ -4459,13 +4458,11 @@ process:
             /* Coerce to integer and set scalar as UV resp. IV */
             if (fields[i].flags & UNSIGNED_FLAG)
             {
-              (void) SvUV(sv);
-              SvIOK_only_UV(sv);
+              sv_setuv(sv, SvUV(sv));
             }
             else
             {
-              (void) SvIV(sv);
-              SvIOK_only(sv);
+              sv_setiv(sv, SvIV(sv));
             }
           }
           break;


### PR DESCRIPTION
Calling SvNV() for magical scalar is not enough for float type conversion.
It caused problem for Amavis in tainted mode -- all float values were zero.
On the other hand SvIV() and SvUV() seems to work fine. To be sure that
correct value of float is in scalar use sv_setnv() with explicit NV float
value. Similar code is changed also for integers IV/UV.

Fixes #78 
Fixes #312 

Credit https://github.com/kentnl-gentoo/DBD-mysql/commit/b6b8540216bd03b68f3bc076b3d3106f4be23f9d