### PR TITLE
Do no assign from un uninitialized slen

### DIFF
--- a/mysql.xs
+++ b/mysql.xs
@@ -264,7 +264,7 @@ do(dbh, statement, attr=Nullsv, ...)
   STRLEN slen;
   char            *str_ptr, *buffer;
   int             has_binded;
-  int             buffer_length= slen;
+  int             buffer_length;
   int             buffer_type= 0;
   int             use_server_side_prepare= 0;
   int             disable_fallback_for_server_prepare= 0;


### PR DESCRIPTION
Some static code analyzers warns on:

    STRLEN slen;
    int    buffer_length = slen;

because slen variable value is not initialized. The assignment is
indeed pointless. This patch removes it.