### PR TITLE
Remove a useless shebang from DBD::mysql

### DIFF
--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 require 5.008_001; # just as DBI


### PR DESCRIPTION
Shebang has only a meaning for an executable script. DBD::mysql Perl
module is not an executable script that someone would run as an
standalone program. Morover, the file would have to have set an
executable bit. It seems the erroneous shebang was added by a mistake
when removing an Emacs configuration line.

This patch removes the shebang.