### PR TITLE
Fix t/05dbcreate.t when configured with --testsocket option

### DIFF
--- a/t/05dbcreate.t
+++ b/t/05dbcreate.t
@@ -9,8 +9,9 @@ use vars qw($test_user $test_password $test_db $test_dsn);
 use lib 't', '.';
 require 'lib.pl';
 
-# remove database from DSN
-$test_dsn =~ s/^DBI:mysql:([^:;]+)([:;]?)/DBI:mysql:$2/;
+# Remove database name from DSN by removing everything beyond the initial
+# string up to first double- or semicolon.
+$test_dsn =~ s/(?<=^DBI:mysql:)[^:;]+//;
 
 my $dbh;
 eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,


### PR DESCRIPTION
The 05dbcreate.t test tries to connect to database without a database
name specified. It does this by taking the DSN being used and removing
the database name. The problem was that the code didn't expect any
additional parameters separated by ';' (like database socket) and so
removed that part of DSN too.

This fixes #323