### PR TITLE
fix detection of client version on MariaDB 10.6.x

### DIFF
--- a/dbdimp.h
+++ b/dbdimp.h
@@ -106,7 +106,10 @@
 /* MYSQL_OPT_SSL_VERIFY_SERVER_CERT automatically enforce SSL mode */
 static inline bool ssl_verify_also_enforce_ssl(void) {
 #ifdef MARIADB_BASE_VERSION
-	my_ulonglong version = mysql_get_client_version();
+	size_t version;
+	/* This will fail to compile with mariadb-connector-c < v3.0.2, but such
+	   old versions are untested and unsupported anyway. */
+	mariadb_get_infov(NULL, MARIADB_CLIENT_VERSION_ID, &version);
 	return ((version >= 50544 && version < 50600) || (version >= 100020 && version < 100100) || version >= 100106);
 #else
 	return false;
@@ -115,10 +118,12 @@ static inline bool ssl_verify_also_enforce_ssl(void) {
 
 /* MYSQL_OPT_SSL_VERIFY_SERVER_CERT is not vulnerable (CVE-2016-2047) and can be used */
 static inline bool ssl_verify_usable(void) {
-	my_ulonglong version = mysql_get_client_version();
 #ifdef MARIADB_BASE_VERSION
+	size_t version;
+	mariadb_get_infov(NULL, MARIADB_CLIENT_VERSION_ID, &version);
 	return ((version >= 50547 && version < 50600) || (version >= 100023 && version < 100100) || version >= 100110);
 #else
+	my_ulonglong version = mysql_get_client_version();
 	return ((version >= 50549 && version < 50600) || (version >= 50630 && version < 50700) || version >= 50712);
 #endif
 }


### PR DESCRIPTION
For mysql_get_client_version(), MariaDB 10.6.2+ reports the version of
the mariadb-connector-c library rather than the server version:
https://jira.mariadb.org/browse/CONC-509

The mariadb-connector-c library versioning does not track the versioning
of the main MariaDB client/server suite, so the change broke the client
version comparisons here in DBD-mysql. The previous behavior of
reporting the _server_ version probably mostly worked by accident, since
server and client versions tend to be roughly aligned in user
environments.

To fix this, change DBD-mysql to use a function which is documented to
return the appropriate client version information.
https://mariadb.com/kb/en/mariadb_get_infov/

NOTE: upstream documentation on mariadb_get_infov is incorrect. The
call modifies a size_t, not a unsigned int.

This fixes:
https://github.com/perl5-dbi/DBD-mysql/issues/333
...and is a minor revision of @bviviano's original fix therein.