### PR TITLE
add DBD::mysql::client_version() to have the client version without DB connections

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2723,7 +2723,7 @@ signed_my_ulonglong2str(my_ulonglong val, char *buf, STRLEN *len)
 }
 #endif
 
-static SV*
+SV*
 my_ulonglong2sv(pTHX_ my_ulonglong val)
 {
 #if IVSIZE >= 8

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -417,3 +417,5 @@ int mysql_db_async_result(SV* h, MYSQL_RES** resp);
 int mysql_db_async_ready(SV* h);
 
 int mysql_socket_ready(my_socket fd);
+
+SV* my_ulonglong2sv(pTHX_ my_ulonglong val);

--- a/mysql.xs
+++ b/mysql.xs
@@ -40,6 +40,12 @@ constant(name, arg)
   OUTPUT:
     RETVAL
 
+SV*
+client_version(pkg)
+  CODE:
+    RETVAL = my_ulonglong2sv(aTHX_ mysql_get_client_version());
+  OUTPUT:
+    RETVAL
 
 MODULE = DBD::mysql	PACKAGE = DBD::mysql::dr
 

--- a/t/version.t
+++ b/t/version.t
@@ -13,4 +13,7 @@ is(
   'VERSION strings should be the same in all .pm files in dist'
 );
 
+diag("mysql_get_client_version: ", DBD::mysql->client_version);
+cmp_ok(DBD::mysql->client_version, ">", 0, "mysql_get_client_version is available as a standalone function");
+
 done_testing;


### PR DESCRIPTION
The value of `mysql_get_client_version()` is available via `$dbh->{clientversion}`, but it would be nicer if we can get the client library version without DB connections; For example, one would like to add or remove `mysql_skip_secure_auth=1` to the dsn according to the client library version. 

---

(edited)

As [@miyagawa said](https://twitter.com/miyagawa/status/1519583966285553664), the following trick works as well: 

```shell-session
$ perl -E 'use DBI; say(DBI::_new_dbh(DBI->driver("dbi:mysql:"))->{mysql_clientversion});'
80028
```

