### PR TITLE
fix some queries with columns beginning with `limit` would fail

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -605,8 +605,8 @@ static char *parse_params(
         it would be good to be able to handle any number of cases and orders
       */
       if (((*statement_ptr == ' ') || (*statement_ptr == '\n') || (*statement_ptr == '\t')) &&
-          (!strncmp(statement_ptr+1, "limit ", 5) ||
-           !strncmp(statement_ptr+1, "LIMIT ", 5)))
+          (!strncmp(statement_ptr+1, "limit ", 6) ||
+           !strncmp(statement_ptr+1, "LIMIT ", 6)))
       {
         limit_flag = 1;
       }

--- a/t/35limit.t
+++ b/t/35limit.t
@@ -19,15 +19,15 @@ eval {$dbh= DBI->connect($test_dsn, $test_user, $test_password,
 if ($@) {
     plan skip_all => "no database connection";
 }
-plan tests => 115;
+plan tests => 117;
 
 ok(defined $dbh, "Connected to database");
 
 ok($dbh->do("DROP TABLE IF EXISTS dbd_mysql_t35"), "making slate clean");
 
-ok($dbh->do("CREATE TABLE dbd_mysql_t35 (id INT(4), name VARCHAR(64), name_limit VARCHAR(64))"), "creating table");
+ok($dbh->do("CREATE TABLE dbd_mysql_t35 (id INT(4), name VARCHAR(64), name_limit VARCHAR(64), limit_by VARCHAR(64))"), "creating table");
 
-ok(($sth = $dbh->prepare("INSERT INTO dbd_mysql_t35 VALUES (?,?,?)")));
+ok(($sth = $dbh->prepare("INSERT INTO dbd_mysql_t35 VALUES (?,?,?,?)")));
 
 for my $i (0..99) {
   my @chars = grep !/[0O1Iil]/, 0..9, 'A'..'Z', 'a'..'z';
@@ -35,7 +35,7 @@ for my $i (0..99) {
 
   # save these values for later testing
   $testInsertVals->{$i} = $random_chars;
-  ok(($rows = $sth->execute($i, $random_chars, $random_chars)));
+  ok(($rows = $sth->execute($i, $random_chars, $random_chars, $random_chars)));
 }
 
 ok($sth = $dbh->prepare("SELECT * FROM dbd_mysql_t35 LIMIT ?, ?"),
@@ -48,6 +48,11 @@ ok( (defined($array_ref = $sth->fetchall_arrayref) &&
   (!defined($errstr = $sth->errstr) || $sth->errstr eq '')));
 
 ok(@$array_ref == 50);
+
+ok($sth = $dbh->prepare("SELECT * FROM dbd_mysql_t35 WHERE limit_by > ?"),
+  "testing prepare of select statement with started by 'limit' column");
+
+ok($sth->execute("foobar"), 'testing exec of bind vars for placeholder');
 
 ok($sth->finish);
 


### PR DESCRIPTION
#288 fixes a problem in which SQL involving columns whose names end in `limit` cannot be generated successfully.
However, this fix caused SQL containing columns starting with `limit` to fail to generate successfully (e.g. `SELECT * FROM table WHERE limit_by > ?`).
This is because the syntax interpretation compares it to `limit` when it should be compared to `limit ` which includes white space.

I have created a fix for this problem and a test code that can confirm this issue.
With 4.050, modified [t/35limit.t](https://github.com/perl5-dbi/DBD-mysql/blob/4f6e91178db41cce4920680800d7a72d9ebe11ff/t/35limit.t) fails, but when this pull request is applied, it succeeds.