### PR TITLE
MYSQL_OPT_RECONNECT is deprecated in MySQL 8.0.34.  Removed support.

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2115,7 +2115,7 @@ MYSQL *mysql_dr_connect(
         we turn off Mysql's auto reconnect and handle re-connecting ourselves
         so that we can keep track of when this happens.
       */
-#if MYSQL_VERSION_ID >= 50013
+#if MYSQL_VERSION_ID >= 50013 && MYSQL_VERSION_ID < 80034
       my_bool reconnect = FALSE;
       mysql_options(result, MYSQL_OPT_RECONNECT, &reconnect);
 #else


### PR DESCRIPTION
Removed support for MYSQL_OPT_RECONNECT for MySQL versions >= 8.0.34

https://github.com/perl5-dbi/DBD-mysql/issues/354