### PR TITLE
Correct handling of mysql_enable_utf8mb4

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1388,6 +1388,7 @@ MYSQL *mysql_dr_connect(
 
         if ((svp = hv_fetch(hv, "mysql_enable_utf8mb4", 20, FALSE)) && *svp && SvTRUE(*svp)) {
           mysql_options(sock, MYSQL_SET_CHARSET_NAME, "utf8mb4");
+          imp_dbh->enable_utf8mb4 = TRUE;
         }
         else if ((svp = hv_fetch(hv, "mysql_enable_utf8", 17, FALSE)) && *svp) {
           /* Do not touch imp_dbh->enable_utf8 as we are called earlier

--- a/t/gh360.t
+++ b/t/gh360.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+use lib 't', '.';
+require 'lib.pl';
+
+my ($dbhA, $dbhB);
+use vars qw($test_dsn $test_user $test_password);
+
+my $dsnA = $test_dsn . ';mysql_enable_utf8mb4=1';
+eval {$dbhA = DBI->connect($dsnA, $test_user, $test_password,
+    { RaiseError => 1, AutoCommit => 1});};
+
+my $dsnB = $test_dsn;
+$dsnB =~ s/DBI:mysql/DBI:mysql(mysql_enable_utf8mb4=1)/;
+eval {$dbhB = DBI->connect($dsnB . ';mysql_enable_utf8mb4=1', $test_user, $test_password,
+    { RaiseError => 1, AutoCommit => 1});};
+
+plan tests => 2;
+
+ok($dbhA->{mysql_enable_utf8mb4} == 1, 'mysql_enable_utf8mb4 == 1 with regular DSN');
+
+ok($dbhB->{mysql_enable_utf8mb4} == 1, 'mysql_enable_utf8mb4 == 1 with driver DSN');


### PR DESCRIPTION
Depending on where in the DSN `mysql_enable_utf8mb4` was specified it would set `imp_dbh->enable_utf8mb4` or not. But it would always call `mysql_options()` to set the charset. This commit makes sure `imp_dbh->enable_utf8mb4` is set consistently.

Closes #360