### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 # DBD::mysql - database driver for Perl
 
-This is the Perl [DBI](https://metacpan.org/pod/DBI) driver for access to MySQL 8.x databases.
+This is the Perl [DBI](https://metacpan.org/pod/DBI) driver for access to MySQL and MySQL Compatible databases.
 
 ## Usage
 
 Usage is described in [DBD::mysql](https://metacpan.org/pod/DBD::mysql).
 
 ## Building and Testing
+
+For building DBD::mysql you need the MySQL 8.x client library.
 
 ```
 perl Makefile.PL


### PR DESCRIPTION
Update the readme to make it clear that DBD::mysql now needs MySQL 8.x
to build, but can be used to connect to MySQL 5.7, 8.0 and other servers
that implement the MySQL Protocol.
