### PR TITLE
Add support for compression algorighm selection

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1233,11 +1233,13 @@ MYSQL *mysql_dr_connect(
         if ((svp = hv_fetch(hv, "mysql_compression", 17, FALSE))  &&
             *svp && SvTRUE(*svp))
         {
+          char* calg = SvPV(*svp, lna);
+          if (strncmp(calg,"1",1) == 0) calg="zlib";
           if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
             PerlIO_printf(DBIc_LOGPIO(imp_xxh),
                           "imp_dbh->mysql_dr_connect: Enabling" \
-                          " compression.\n");
-          mysql_options(sock, MYSQL_OPT_COMPRESS, NULL);
+                          " compression algorithms: %s\n", calg);
+          mysql_options(sock, MYSQL_OPT_COMPRESSION_ALGORITHMS, calg);
         }
         if ((svp = hv_fetch(hv, "mysql_connect_timeout", 21, FALSE))
             &&  *svp  &&  SvTRUE(*svp))

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1060,8 +1060,12 @@ specify "mysql_client_found_rows=0" in the DSN.
 
 =item mysql_compression
 
-If your DSN contains the option "mysql_compression=1", then the communication
-between client and server will be compressed.
+If your DSN contains the option "mysql_compression", then this will be used
+to set the compression algorithms for the connection.
+
+If your DSN contains the option "mysql_compression=1", then the compression
+algorithms will be set to "zlib". This is for backwards compatibility with
+older versions of DBD::mysql.
 
 =item mysql_connect_timeout
 

--- a/t/99compression.t
+++ b/t/99compression.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+use lib 't', '.';
+require 'lib.pl';
+
+foreach my $compression ( "zlib", "zstd", "0", "1" ) {
+  my ($dbh, $sth, $row);
+  use vars qw($test_dsn $test_user $test_password);
+  
+  eval {$dbh = DBI->connect($test_dsn . ";mysql_compression=$compression", $test_user, $test_password,
+      { RaiseError => 1, AutoCommit => 1});};
+  
+  ok ($sth= $dbh->prepare("SHOW SESSION STATUS LIKE 'Compression_algorithm'"));
+  
+  ok $sth->execute();
+  
+  ok ($row= $sth->fetchrow_arrayref);
+
+  my $exp = $compression;
+  if ($exp eq "1") { $exp = "zlib" };
+  if ($exp eq "0") { $exp = "" };
+  cmp_ok $row->[1], 'eq', $exp, "\$row->[1] eq $exp";
+  
+  ok $sth->finish;
+}
+
+plan tests => 4*5;


### PR DESCRIPTION
1. Avoid using `MYSQL_OPT_COMPRESS` as it is deprecated since MySQL 8.0.18
2. Allow compression algorithm selection by setting `mysql_compression=zstd` or `mysql_compression=zlib`.

See also: https://dev.mysql.com/doc/c-api/8.0/en/mysql-options.html