### PR TITLE
Enable auto reconnect for ER_CLIENT_INTERACTION_TIMEOUT

### DIFF
--- a/t/15reconnect.t
+++ b/t/15reconnect.t
@@ -16,7 +16,7 @@ eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
 if ($@) {
   plan skip_all => "no database connection";
 }
-plan tests => 28;
+plan tests => 34;
 
 for my $mysql_server_prepare (0, 1) {
 $dbh= DBI->connect("$test_dsn;mysql_server_prepare=$mysql_server_prepare;mysql_server_prepare_disable_fallback=1", $test_user, $test_password,
@@ -29,6 +29,11 @@ ok($dbh->{Active}, "checking for active handle");
 ok($dbh->{mysql_auto_reconnect} = 1, "enabling reconnect");
 
 ok($dbh->{AutoCommit} = 1, "enabling autocommit");
+
+ok ($dbh->do("SET SESSION wait_timeout=2"));
+sleep(3);
+ok($dbh->do("SELECT 1"), "implicitly reconnecting handle with 'do'");
+ok($dbh->{Active}, "checking for reactivated handle");
 
 ok($dbh->disconnect(), "disconnecting active handle");
 


### PR DESCRIPTION
Previously waiting for more than the `wait_timeout` would result in `CR_SERVER_LOST`, but now the server tries to notify the client about the reason it was disconnected and this results in a different error.

Closes #162

See also:
- https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-24.html#mysqld-8-0-24-connection-management
- https://dev.mysql.com/worklog/task/?id=12999
- https://bugs.mysql.com/bug.php?id=93240

```perl
#!/bin/perl
use v5.36;
use DBI;
use Data::Dumper;


my $dbh = DBI->connect('DBI:mysql:database=test', 'root', 'Root123@', {
    mysql_auto_reconnect => 1,
    RaiseError => 1,
    AutoCommit => 1,
});

my $res = $dbh->selectall_arrayref("SELECT CONNECTION_ID()");
say "Connection ID: " . @$res[0]->[0];
say "Stats:\n- auto_reconnects_ok=" . $dbh->{mysql_dbd_stats}->{auto_reconnects_ok};
say "- auto_reconnects_failed=" . $dbh->{mysql_dbd_stats}->{auto_reconnects_failed};

$dbh->do("SET SESSION wait_timeout=3");
sleep(4);

$res = $dbh->selectall_arrayref("SELECT CONNECTION_ID()");
say "Connection ID: " . @$res[0]->[0];
say "Stats:\n- auto_reconnects_ok=" . $dbh->{mysql_dbd_stats}->{auto_reconnects_ok};
say "- auto_reconnects_failed=" . $dbh->{mysql_dbd_stats}->{auto_reconnects_failed};

$dbh->do("ROLLBACK RELEASE");

$res = $dbh->selectall_arrayref("SELECT CONNECTION_ID()");
say "Connection ID: " . @$res[0]->[0];
say "Stats:\n- auto_reconnects_ok=" . $dbh->{mysql_dbd_stats}->{auto_reconnects_ok};
say "- auto_reconnects_failed=" . $dbh->{mysql_dbd_stats}->{auto_reconnects_failed};
```

```
$ ~/reconnect.pl 
Connection ID: 425
Stats:
- auto_reconnects_ok=0
- auto_reconnects_failed=0
Connection ID: 426
Stats:
- auto_reconnects_ok=1
- auto_reconnects_failed=0
Connection ID: 427
Stats:
- auto_reconnects_ok=2
- auto_reconnects_failed=0
```