### PR TITLE
More cleanups of unneeded ifdefs

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3968,12 +3968,8 @@ dbd_st_FETCH_internal(
         break;
 
       case AV_ATTRIB_IS_AUTO_INCREMENT:
-#if defined(AUTO_INCREMENT_FLAG)
         sv= boolSV(IS_AUTO_INCREMENT(curField->flags));
         break;
-#else
-        croak("AUTO_INCREMENT_FLAG is not supported on this machine");
-#endif
 
       case AV_ATTRIB_IS_KEY:
         sv= boolSV(IS_KEY(curField->flags));

--- a/mysql.xs
+++ b/mysql.xs
@@ -774,16 +774,9 @@ dbd_mysql_get_info(dbh, sql_info_type)
 	    retsv = newSVpvn("`", 1);
 	    break;
 	case SQL_MAXIMUM_STATEMENT_LENGTH:
-        /* net_buffer_length macro is not defined in MySQL 5.7 and some MariaDB
-        versions - if it is not available, use newer mysql_get_option */
-#if !defined(net_buffer_length)
-            ;
 	    unsigned long buffer_len;
 	    mysql_get_option(NULL, MYSQL_OPT_NET_BUFFER_LENGTH, &buffer_len);
 	    retsv = newSViv(buffer_len);
-#else
-	    retsv = newSViv(net_buffer_length);
-#endif
 	    break;
 	case SQL_MAXIMUM_TABLES_IN_SELECT:
 	    /* newSViv((sizeof(int) > 32) ? sizeof(int)-1 : 31 ); in general? */

--- a/mysql.xs
+++ b/mysql.xs
@@ -774,6 +774,7 @@ dbd_mysql_get_info(dbh, sql_info_type)
 	    retsv = newSVpvn("`", 1);
 	    break;
 	case SQL_MAXIMUM_STATEMENT_LENGTH:
+	    ; /* avoid "a label can only be part of a statement and a declaration is not a statement" */
 	    unsigned long buffer_len;
 	    mysql_get_option(NULL, MYSQL_OPT_NET_BUFFER_LENGTH, &buffer_len);
 	    retsv = newSViv(buffer_len);


### PR DESCRIPTION
- `AUTO_INCREMENT_FLAG` is always defined
- `net_buffer_length` is never defined