### PR TITLE
Update install docs for macOS

### DIFF
--- a/lib/DBD/mysql/INSTALL.pod
+++ b/lib/DBD/mysql/INSTALL.pod
@@ -542,7 +542,14 @@ mysql client libs. The easiest way to install these is using Homebrew
 
 Once you have Homebrew set up, you can simply install the dependencies using
 
-    brew install openssl mysql-connector-c
+    brew install openssl@3 mysql-client
+
+Then make sure to add the path for L<mysql_config> to your path:
+
+    export PATH=/usr/local/Cellar/mysql-client/8.1.0/bin:$PATH
+
+Make sure to use the correct path for your installation. Check the output of L<brew list mysql-client>
+to see the correct path. You can use L<~/.zshrc> to set the path for future sessions as well.
 
 Then you can install DBD::mysql using your cpan client.
 


### PR DESCRIPTION
To verify support for DBD::mysql on macOS I have:

- Added CI tests ( https://github.com/perl5-dbi/DBD-mysql/blob/master/.github/workflows/ci_mac.yml )
- Updated the docs (this PR)
- Done some manual tests (see below)

I've installed DBD::mysql on this host via `cpanm` and `cpan`.
As dependency I have tested with both `mysql-client` (8.1.0) and `mysql-client@8.0` (8.0.35). Both installed via brew.

```
ec2-user@ip-172-31-29-149 ~ % sw_vers                                                                            
ProductName:		macOS
ProductVersion:		13.5.2
BuildVersion:		22G91
ec2-user@ip-172-31-29-149 ~ % which perl                                                                         
/usr/local/bin/perl
ec2-user@ip-172-31-29-149 ~ % perl -v                                                                            


This is perl 5, version 38, subversion 0 (v5.38.0) built for darwin-thread-multi-2level

Copyright 1987-2023, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at https://www.perl.org/, the Perl Home Page.

ec2-user@ip-172-31-29-149 ~ % perl -e 'use DBD::mysql; print "This is DBD::mysql " . $DBD::mysql::VERSION . "\n"'
This is DBD::mysql 5.002
```

Related issues:
- Closes #347 
- Closes #341
- Closes #337 
- Closes #322 
- Closes #298 

If you encounter any issues on macOS, please report the following:
- `mysql_config` output
- `perl -v` output
- `sw_vers` output
- build log
- `uname -mp` and/or `machine` output to identify the CPU architecture.