### PR TITLE
Update mysql-apt-config to 0.8.29-1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
           EOF
       - name: "Setup mysql libs"
         run: |
-          wget https://dev.mysql.com/get/mysql-apt-config_0.8.26-1_all.deb
-          DEBIAN_FRONTEND="noninteractive" sudo dpkg -i mysql-apt-config_0.8.26-1_all.deb
+          wget https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb
+          DEBIAN_FRONTEND="noninteractive" sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
           sudo apt update
           sudo apt install -y libmysqlclient-dev
       - name: "Run build"


### PR DESCRIPTION
In #413 the CI checks failed because of this:

```
 Hit:5 http://azure.archive.ubuntu.com/ubuntu focal-security InRelease
Hit:6 https://packages.microsoft.com/ubuntu/20.04/prod focal InRelease
Get:7 http://repo.mysql.com/apt/ubuntu focal InRelease [12.8 kB]
Err:7 http://repo.mysql.com/apt/ubuntu focal InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B7B3B788A8D3785C
Hit:8 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal InRelease
Reading package lists...
W: GPG error: http://repo.mysql.com/apt/ubuntu focal InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B7B3B788A8D3785C
E: The repository 'http://repo.mysql.com/apt/ubuntu focal InRelease' is not signed.
Error: Process completed with exit code 100.
```

This PR is to update the CI checks to fix this.