### PR TITLE
Replace mysql_stmt_bind_param() with mysql_stmt_bind_named_param()

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2924,7 +2924,11 @@ my_ulonglong mysql_st_internal_execute41(
 
   if (num_params > 0 && !(*has_been_bound))
   {
+#if MYSQL_VERSION_ID >= 80300
+    if (mysql_stmt_bind_named_param(stmt,bind,num_params, NULL))
+#else
     if (mysql_stmt_bind_param(stmt,bind))
+#endif
       goto error;
 
     *has_been_bound= 1;


### PR DESCRIPTION
Closes #375 

- Deprecated: https://dev.mysql.com/doc/c-api/8.3/en/mysql-stmt-bind-param.html
- Replacement: https://dev.mysql.com/doc/c-api/8.3/en/mysql-stmt-bind-named-param.html
- https://dev.mysql.com/doc/relnotes/mysql/8.2/en/news-8-2-0.html#mysqld-8-2-0-capi
- https://dev.mysql.com/doc/relnotes/mysql/8.3/en/news-8-3-0.html#mysqld-8-3-0-deprecation-removal
- https://bugs.mysql.com/bug.php?id=112893

Unfortunately the new `mysql_stmt_bind_named_param()` only really works in 8.3.0 so we need an `ifdef` to allow this to be build against earlier versions.