### PR TITLE
docs: Update package names and MariaDB related things

### DIFF
--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1376,19 +1376,19 @@ against:
 
   print "$dbh->{mysql_clientinfo}\n";
 
-  5.2.0-MariaDB
+  8.3.0
 
 =item mysql_clientversion
 
   print "$dbh->{mysql_clientversion}\n";
 
-  50200
+  80300
 
 =item mysql_serverversion
 
   print "$dbh->{mysql_serverversion}\n";
 
-  50200
+  80300
 
 =item mysql_dbd_stats
 
@@ -1537,7 +1537,7 @@ character column, if this column is indexed, if you query that
 column with the integer value not being quoted, it will not
 use the index:
 
-    MariaDB [test]> explain select * from test where value0 = '3' \G
+    mysql> explain select * from test where value0 = '3' \G
     *************************** 1. row ***************************
                id: 1
       select_type: SIMPLE
@@ -1551,7 +1551,7 @@ use the index:
             Extra: Using index condition
     1 row in set (0.00 sec)
 
-    MariaDB [test]> explain select * from test where value0 = 3
+    mysql> explain select * from test where value0 = 3
         -> \G
     *************************** 1. row ***************************
                id: 1

--- a/lib/DBD/mysql/INSTALL.pod
+++ b/lib/DBD/mysql/INSTALL.pod
@@ -204,15 +204,12 @@ To run the tests that ship with the module, you'll need access to a
 running MySQL server. This can be running on localhost, but it can also
 be on a remote machine.
 
-On Fedora the process is as follows. Please note that Fedora actually
-ships with MariaDB but not with MySQL. This is not a problem, it
-will work just as well.
-In this example we install and start a local server for running the
-tests against.
+On Fedora the process is as follows. In this example we install and
+start a local server for running the tests against.
 
-    dnf -y install make gcc mariadb-devel mariadb-libs mariadb-server
+    dnf -y install make gcc community-mysql-devel community-mysql-libs community-mysql-server
     dnf -y install "perl(Test::Deep)" "perl(Test::More)"
-    systemctl start mariadb.service
+    systemctl start mysqld.service
 
 
 =head2 Environment Variables


### PR DESCRIPTION
- Fedora now has both MySQL and MariaDB packages (more changes might be coming in the future: https://lwn.net/Articles/960630/ )
- DBD::mysql requires MySQL 8.x
- MariaDB 5.2.0 is very old (a lot has happened since)

@michal-josef-spacek I found this while checking #420 , maybe you can give this a quick check?