### PR TITLE
Update test for `have_ssl` removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
             server: "8.0"
           - os: ubuntu-20.04
             client: "8.0"
-            server: "8.3"
+            server: "8.4"
           - os: ubuntu-22.04
-            client: "8.3"
-            server: "8.3"
+            client: "8.4"
+            server: "8.4"
           - os: ubuntu-22.04
-            client: "8.3"
+            client: "8.4"
             server: "8.0"
     runs-on: ${{ matrix.os }}
     services:
@@ -40,15 +40,15 @@ jobs:
           sudo debconf-set-selections <<EOF
           mysql-apt-config      mysql-apt-config/select-server  select  mysql-8.0
           EOF
-      - if: matrix.client == '8.3'
+      - if: matrix.client == '8.4'
         run: |
           sudo debconf-set-selections <<EOF
-          mysql-apt-config      mysql-apt-config/select-server  select  mysql-innovation
+          mysql-apt-config      mysql-apt-config/select-server  select  mysql-8.4-lts
           EOF
       - name: "Setup mysql libs"
         run: |
-          wget https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb
-          DEBIAN_FRONTEND="noninteractive" sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
+          wget https://dev.mysql.com/get/mysql-apt-config_0.8.30-1_all.deb
+          DEBIAN_FRONTEND="noninteractive" sudo dpkg -i mysql-apt-config_0.8.30-1_all.deb
           sudo apt update
           sudo apt install -y libmysqlclient-dev
       - name: "Run build"

--- a/t/92ssl_backronym_vulnerability.t
+++ b/t/92ssl_backronym_vulnerability.t
@@ -13,6 +13,9 @@ my $have_ssl = eval { $dbh->selectrow_hashref("SHOW VARIABLES WHERE Variable_nam
 $dbh->disconnect();
 plan skip_all => 'Server supports SSL connections, cannot test false-positive enforcement' if $have_ssl and $have_ssl->{Value} eq 'YES';
 
+# `have_ssl` has been deprecated in 8.0.26 and removed in 8.4.0...
+plan skip_all => 'Server might support SSL connections, cannot test false-positive enforcement' if not $have_ssl;
+
 plan tests => 4;
 
 $dbh = DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 0, mysql_ssl => 1 });

--- a/t/92ssl_optional.t
+++ b/t/92ssl_optional.t
@@ -13,6 +13,9 @@ my $have_ssl = eval { $dbh->selectrow_hashref("SHOW VARIABLES WHERE Variable_nam
 $dbh->disconnect();
 plan skip_all => 'Server supports SSL connections, cannot test fallback to plain text' if $have_ssl and $have_ssl->{Value} eq 'YES';
 
+# `have_ssl` has been deprecated in 8.0.26 and removed in 8.4.0...
+plan skip_all => 'Server might support SSL connections, cannot test false-positive enforcement' if not $have_ssl;
+
 plan tests => 2;
 
 $dbh = DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 0, mysql_ssl => 1, mysql_ssl_optional => 1 });

--- a/t/92ssl_riddle_vulnerability.t
+++ b/t/92ssl_riddle_vulnerability.t
@@ -13,6 +13,9 @@ my $have_ssl = eval { $dbh->selectrow_hashref("SHOW VARIABLES WHERE Variable_nam
 $dbh->disconnect();
 plan skip_all => 'Server supports SSL connections, cannot test false-positive enforcement' if $have_ssl and $have_ssl->{Value} eq 'YES';
 
+# `have_ssl` has been deprecated in 8.0.26 and removed in 8.4.0...
+plan skip_all => 'Server might support SSL connections, cannot test false-positive enforcement' if not $have_ssl;
+
 plan tests => 4;
 
 $dbh = DBI->connect($test_dsn, '4yZ73s9qeECdWi', '64heUGwAsVoNqo', { PrintError => 0, RaiseError => 0, mysql_ssl => 1 });


### PR DESCRIPTION
Closes #424 

From https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-0.html

"The --ssl and --admin-ssl server options, as well as the have_ssl and have_openssl server system variables, were all deprecated in MySQL 8.0.26, and are all removed in this release. Use --tls-version and --admin-tls-version instead."

So testing for `have_ssl` no longer works as expected.

Also removal of `--ssl`/`--skip-ssl` makes testing this more difficult.