### PR TITLE
Fix calls to mysql_server_end()/mysql_library_end()

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1827,7 +1827,7 @@ int dbd_discon_all (SV *drh, imp_drh_t *imp_drh) {
   dTHX;
   PERL_UNUSED_ARG(drh);
 
-  mysql_server_end();
+  mysql_library_end();
 
   /* The disconnect_all concept is flawed and needs more work */
   if (!PL_dirty && !SvTRUE(perl_get_sv("DBI::PERL_ENDING",0))) {
@@ -1871,7 +1871,6 @@ void dbd_db_destroy(SV* dbh, imp_dbh_t* imp_dbh) {
     }
     dbd_db_disconnect(dbh, imp_dbh);
   }
-  mysql_library_end();
   Safefree(imp_dbh->pmysql);
 
   /* Tell DBI, that dbh->destroy must no longer be called */

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -237,6 +237,7 @@ struct imp_sth_st {
 #define dbd_db_destroy		mysql_db_destroy
 #define dbd_db_STORE_attrib	mysql_db_STORE_attrib
 #define dbd_db_FETCH_attrib	mysql_db_FETCH_attrib
+#define dbd_discon_all		mysql_discon_all
 #define dbd_st_prepare		mysql_st_prepare
 #define dbd_st_execute		mysql_st_execute
 #define dbd_st_fetch		mysql_st_fetch


### PR DESCRIPTION
- Stop calling `mysql_library_end()` in `dbd_db_destroy()` as this leads to issues with OpenSSL in specific circumstances.
- Call `myql_library_end()` instead of `mysql_server_end()` as the latter has been deprecated.

See also:
- https://dev.mysql.com/doc/c-api/8.4/en/mysql-server-end.html
- https://dev.mysql.com/doc/c-api/8.4/en/mysql-library-end.html

Closes #431