### PR TITLE
51bind_type_guessing.t: Update for 9.0.0 errorcodes

### DIFF
--- a/t/51bind_type_guessing.t
+++ b/t/51bind_type_guessing.t
@@ -135,7 +135,11 @@ for my $i (0 .. 11) {
         eval {
             $rows = $sts[1]->execute($val, $i);
         };
-        like ($@, qr{Data truncated for column}, $t);
+        if ($dbh->{mysql_serverversion} < 90000) {
+            like ($@, qr{Data truncated for column}, $t);
+        } else {
+            like ($@, qr{Incorrect DOUBLE value}, $t);
+        }
         $rows= $sts[1]->execute(0, $i);
     }
     else {


### PR DESCRIPTION
Closes #434 

```
mysql-8.4.0> create table t1(id int primary key, dd double);
Query OK, 0 rows affected (0.02 sec)

mysql-8.4.0> insert into t1 values(1,'5e');
ERROR 1265 (01000): Data truncated for column 'dd' at row 1
```

```
mysql-9.0.0> create table t1(id int primary key, dd double);
Query OK, 0 rows affected (0.03 sec)

mysql-9.0.0> insert into t1 values(1,'5e');
ERROR 1366 (HY000): Incorrect DOUBLE value: '5e' for column 'dd' at row 1
```