### PR TITLE
Make `statistics_info` use catalog arg

### DIFF
--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -738,12 +738,10 @@ EOF
     my @where;
     my @bind;
 
-    # catalogs are not yet supported by MySQL
-
-#    if (defined $catalog) {
-#        push @where, 'TABLE_CATALOG = ?';
-#        push @bind, $catalog;
-#    }
+    if (defined $catalog) {
+        push @where, 'TABLE_CATALOG = ?';
+        push @bind, $catalog;
+    }
 
     if (defined $schema) {
         push @where, 'TABLE_SCHEMA = ?';

--- a/t/40keyinfo.t
+++ b/t/40keyinfo.t
@@ -43,11 +43,16 @@ is_deeply([ $dbh->primary_key(undef, undef, 'dbd_mysql_keyinfo') ], [ 'a', 'b' ]
 
 $sth= $dbh->statistics_info(undef, undef, 'dbd_mysql_keyinfo', 0, 0);
 my $stats_info = $sth->fetchall_arrayref;
+my $n_catalogs = @$stats_info;
 my $n_unique = grep $_->[3], @$stats_info;
 $sth= $dbh->statistics_info(undef, undef, 'dbd_mysql_keyinfo', 1, 0);
 $stats_info = $sth->fetchall_arrayref;
 my $n_unique2 = grep $_->[3], @$stats_info;
 isnt($n_unique2, $n_unique, "Check statistics_info unique_only flag has an effect");
+$sth= $dbh->statistics_info('nonexist', undef, 'dbd_mysql_keyinfo', 0, 0);
+$stats_info = $sth->fetchall_arrayref;
+my $n_catalogs2 = @$stats_info;
+isnt($n_catalogs2, $n_catalogs, "Check statistics_info catalog arg has an effect");
 
 ok($dbh->do("DROP TABLE dbd_mysql_keyinfo"), "Dropped table");
 


### PR DESCRIPTION
Sorry for taking two goes at this. It was bothering me today that I saw the catalog info coming back from the db, but I knew `statistics_info` had filtering on that disabled. Now it's not (with a test, and everything!).