### PR TITLE
Test for LIMIT case insensitive

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -475,8 +475,7 @@ static char *parse_params(
         it would be good to be able to handle any number of cases and orders
       */
       if (((*statement_ptr == ' ') || (*statement_ptr == '\n') || (*statement_ptr == '\t')) &&
-          (!strncmp(statement_ptr+1, "limit ", 6) ||
-           !strncmp(statement_ptr+1, "LIMIT ", 6)))
+          (!strncasecmp(statement_ptr+1, "limit ", 6)))
       {
         limit_flag = 1;
       }


### PR DESCRIPTION
The test was testing for `LIMIT` and `limit` but didn't work for `Limit` etc.

Follow up for https://github.com/perl5-dbi/DBD-mysql/pull/349

@kebhr @mohawk2 what do you think about this?

I think `strncasecmp` may not be available on Windows, so this might need an `ifdef` with a Windows specific solution.