### PR TITLE
Use safer quoting for placeholders

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -636,7 +636,7 @@ static char *parse_params(
             if (!is_num)
             {
               *ptr++ = '\'';
-              ptr += mysql_real_escape_string(sock, ptr, valbuf, vallen);
+              ptr += mysql_real_escape_string_quote(sock, ptr, valbuf, vallen, '\'');
               *ptr++ = '\'';
             }
             else

--- a/t/17quote.t
+++ b/t/17quote.t
@@ -23,13 +23,19 @@ my @results_ansi = (qw/ 'foo' 'foo\'bar' 'foo\\\\bar'/);
 my @results_no_backlslash = (qw/ 'foo' 'foo''bar' 'foo\\bar'/);
 my @results = (\@results_empty, \@results_ansi, \@results_no_backlslash);
 
-plan tests => (@sqlmodes * @words * 2 + 1);
+plan tests => (@sqlmodes * @words * 3 + 1);
 
 while (my ($i, $sqlmode) = each @sqlmodes) {
   $dbh->do("SET sql_mode=?", undef,  $sqlmode eq "empty" ? "" : $sqlmode);
   for my $j (0..@words-1) {
     ok $dbh->quote($words[$j]);
     cmp_ok($dbh->quote($words[$j]), "eq", $results[$i][$j], "$sqlmode $words[$j]");
+
+    is(
+        $dbh->selectrow_array('SELECT ?', undef, $words[$j]),
+        $words[$j],
+        "Round-tripped '$words[$j]' through a placeholder query"
+    );
   }
 }
 


### PR DESCRIPTION
Switch to mysql_real_escape_string_quote for placeholder replacement, allowing placeholders to be used when NO_BACKSLASH_ESCAPES is in effect.