### PR TITLE
Fix tests failing on MariaDB

### DIFF
--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1261,7 +1261,7 @@ In this case DBD::mysql fallbacks to normal non-prepared statement and tries aga
 
 =item mysql_server_prepare_disable_fallback
 
-This option disable fallback to normal non-prepared statement when mysql server
+This option disables fallback to normal non-prepared statement when mysql server
 does not support execution of current statement as prepared.
 
 Useful when you want to be sure that statement is going to be executed as

--- a/t/40server_prepare.t
+++ b/t/40server_prepare.t
@@ -88,13 +88,13 @@ my $dbname = $dbh->selectrow_arrayref("SELECT DATABASE()")->[0];
 $dbh->{mysql_server_prepare_disable_fallback} = 1;
 my $error_handler_called = 0;
 $dbh->{HandleError} = sub { $error_handler_called = 1; die $_[0]; };
-eval { $dbh->prepare("USE $dbname") };
+eval { $dbh->prepare('PREPARE stmt FROM "SELECT 1"') };
 $dbh->{HandleError} = undef;
-ok($error_handler_called, 'USE is not supported with mysql_server_prepare_disable_fallback=1');
+ok($error_handler_called, 'PREPARE statement is not supported with mysql_server_prepare_disable_fallback=1');
 
 $dbh->{mysql_server_prepare_disable_fallback} = 0;
 my $sth4;
-ok($sth4 = $dbh->prepare("USE $dbname"), 'USE is supported with mysql_server_prepare_disable_fallback=0');
+ok($sth4 = $dbh->prepare('PREPARE stmt FROM "SELECT 1"'), 'PREPARE statement is supported with mysql_server_prepare_disable_fallback=0');
 ok($sth4->execute());
 ok($sth4->finish());
 

--- a/t/99compression.t
+++ b/t/99compression.t
@@ -21,6 +21,10 @@ if ($dbh->{mysql_serverversion} < 80000) {
   plan skip_all => "test requires 8.x or newer";
 }
 
+if ($dbh->{'mysql_serverinfo'} =~ 'MariaDB') {
+  plan skip_all => "No zstd or Compression_algorithm on MariaDB";
+}
+
 foreach my $compression ( "zlib", "zstd", "0", "1" ) {
   my ($dbh, $sth, $row);
   


### PR DESCRIPTION
This only fixes:

- `t/40server_prepare.t` (Looks like `USE...` can be in a prepared statement on MariaDB)
- `t/99compression.t` (MariaDB doesn't follow the new zstd/zlib options from MySQL)

There is at least one other test that needs fixing.

Tested locally with MariaDB Server 11.7.2


Ref #468 