### PR TITLE
Add support for JSON column in column_info()

### DIFF
--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -459,7 +459,7 @@ sub column_info {
 	  my @type_attr= split / /, $attr||'';
 
   	$info->{DATA_TYPE}= SQL_VARCHAR();
-    if ($basetype =~ /^(char|varchar|\w*text|\w*blob)/)
+    if ($basetype =~ /^(char|varchar|\w*text|\w*blob|json)/)
     {
       $info->{DATA_TYPE}= SQL_CHAR() if $basetype eq 'char';
       if ($type_params[0])
@@ -471,7 +471,7 @@ sub column_info {
         $info->{COLUMN_SIZE} = 65535;
         $info->{COLUMN_SIZE} = 255        if $basetype =~ /^tiny/;
         $info->{COLUMN_SIZE} = 16777215   if $basetype =~ /^medium/;
-        $info->{COLUMN_SIZE} = 4294967295 if $basetype =~ /^long/;
+        $info->{COLUMN_SIZE} = 4294967295 if $basetype =~ /^(long|json)/;
       }
     }
 	  elsif ($basetype =~ /^(binary|varbinary)/)


### PR DESCRIPTION
Field storage requirement for JSON column is approximately the same as for a LONGBLOB or LONGTEXT column.

It's defined in
https://dev.mysql.com/doc/refman/8.4/en/storage-requirements.html#data-types-storage-reqs-json