### PR TITLE
#475: Improve error message for unsupported named parameters

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4211,6 +4211,23 @@ int dbd_bind_ph(SV *sth, imp_sth_t *imp_sth, SV *param, SV *value,
 
   if (param_num <= 0  ||  param_num > DBIc_NUM_PARAMS(imp_sth))
   {
+    if (!looks_like_number(param))
+    {
+      STRLEN len;
+      char *paramstring;
+      paramstring = SvPV(param, len);
+      if(paramstring[len] == 0 && strlen(paramstring) == len)
+      {
+        do_error(sth, JW_ERR_ILLEGAL_PARAM_NUM, form("named parameters are unsupported: %s", paramstring), NULL);
+        return FALSE;
+      }
+      else
+      {
+        do_error(sth, JW_ERR_ILLEGAL_PARAM_NUM, "<param> could not be coerced to a C string", NULL);
+        return FALSE;
+      }
+    }
+
     do_error(sth, JW_ERR_ILLEGAL_PARAM_NUM, "Illegal parameter number", NULL);
     return FALSE;
   }

--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1725,6 +1725,11 @@ parameter value and C<execute> the statement again, with other values
 unchanged. The attribute remains properly populated after the C<finish> 
 method is called, with the values from the last execution.
 
+MySQL does not support named place holders in C<bind_param>.  If a
+string is passed to C<bind_param> as the parameter index then a
+`JW_ERR_ILLEGAL_PARAM_NUM` with a message of "named parameters are
+unsupported" error is reported.
+
 =item mysql_gtids
 
 Returns GTID(s) if GTID session tracking is ensabled in the server via

--- a/t/45bindnamedparam_error.t
+++ b/t/45bindnamedparam_error.t
@@ -1,0 +1,68 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+use vars qw($test_dsn $test_user $test_password);
+use lib 't', '.';
+require 'lib.pl';
+
+my $dbh;
+eval {$dbh = DBI->connect($test_dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1}) or ServerError();};
+
+if ($@) {
+    plan skip_all => "no database connection";
+}
+plan tests => 15;
+
+SKIP: {
+    ok $dbh->do('SET @@auto_increment_offset = 1');
+    ok $dbh->do('SET @@auto_increment_increment = 1');
+}
+
+my $create= <<EOT;
+CREATE TEMPORARY TABLE dbd_mysql_t45bindnamedparam (
+    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    num INT(3))
+EOT
+
+ok $dbh->do($create), "create table dbd_mysql_t45bindnamedparam";
+
+ok $dbh->do("INSERT INTO dbd_mysql_t45bindnamedparam VALUES(NULL, 1)"), "insert into dbd_mysql_t45bindnamedparam (null, 1)";
+
+my $rows;
+ok ($rows= $dbh->selectall_arrayref("SELECT * FROM dbd_mysql_t45bindnamedparam"));
+
+is $rows->[0][1], 1, "\$rows->[0][1] == 1";
+
+my $sth;
+ok ($sth = $dbh->prepare("SELECT * FROM dbd_mysql_t45bindnamedparam WHERE num = :num"));
+
+$dbh->{PrintError} = 0;
+$dbh->{PrintWarn} = 0;
+eval {($sth->bind_param(":num", 1, SQL_INTEGER()));};
+$dbh->{PrintError} = 1;
+$dbh->{PrintWarn} = 1;
+ok defined($DBI::errstr);
+
+like($DBI::errstr, qr/named parameters are unsupported/, 'bind_param reports expected error with named parameter (string type)');
+
+ok ($sth->finish());
+
+
+ok ($sth = $dbh->prepare("SELECT * FROM dbd_mysql_t45bindnamedparam WHERE num = :num"));
+
+$dbh->{PrintError} = 0;
+$dbh->{PrintWarn} = 0;
+eval {($sth->bind_param("\0:num", 1, SQL_INTEGER()));};
+$dbh->{PrintError} = 1;
+$dbh->{PrintWarn} = 1;
+ok defined($DBI::errstr);
+
+like($DBI::errstr, qr/could not be coerced to a C string/, 'bind_param reports expected error with named parameter (non-string type)');
+
+ok ($sth->finish());
+
+
+ok ($dbh->disconnect());


### PR DESCRIPTION
Previously just 'Illegal parameter number' was logged, make this a more helpful message.

```
[25-05-06 20:46:04.2629] Slim::Schema::Storage::throw_exception (122) Error: DBI Exception: DBD::mysql::st bind_param failed: named parameters are unsupported: :album [for Statement "
                                        SELECT contributor_album.role AS role, contributors.name AS name, contributors.id AS id
                                        FROM contributor_album
                                        JOIN contributors ON contributors.id = contributor_album.contributor
                                        WHERE contributor_album.album = :album
                                        AND contributor_album.role IN (5,1)
                                        ORDER BY contributor_album.role, contributors.namesort
                                "]
```