### PR TITLE
v4: mysql_dr_connect: check return value of mysql_init()

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1689,7 +1689,8 @@ MYSQL *mysql_dr_connect(
 #else
     client_flag = CLIENT_FOUND_ROWS;
 #endif
-    mysql_init(sock);
+    if (!mysql_init(sock))
+      croak("mysql_init failed");
 
     if (imp_dbh)
     {


### PR DESCRIPTION
Original patch provided by Andrew Brown in #488

cc @ndrwbrwn